### PR TITLE
[wip] Add additional bitmaps for application use

### DIFF
--- a/configure
+++ b/configure
@@ -74,6 +74,8 @@ c.append('ldflags', '-Wl,-Bsymbolic-functions')
 c.append('ldflags', '-Wl,-z,now,-z,relro')
 c.append('ldflags', '-ftls-model=initial-exec')
 
+c.append('ldflags', '-static-libstdc++ -static-libgcc')
+
 c.append('libs', '-lm -lpthread')
 c.append('libs', '-ldl')
 

--- a/src/globalmeshingheap.h
+++ b/src/globalmeshingheap.h
@@ -265,7 +265,21 @@ public:
     }
   }
 
-  int bitmapGet(enum mesh::BitType type, void *ptr) {
+  inline bool inBounds(void *ptr) const {
+    if (unlikely(ptr == nullptr))
+      return false;
+
+    auto mh = miniheapFor(ptr);
+    if (likely(mh)) {
+      mh->unref();
+      return true;
+    } else {
+      std::lock_guard<std::mutex> lock(_bigMutex);
+      return _bigheap.inBounds(ptr);
+    }
+  }
+
+  int bitmapGet(enum mesh::BitType type, void *ptr) const {
     if (unlikely(ptr == nullptr))  // || internal::isMeshMarker(ptr))
       return 0;
 

--- a/src/globalmeshingheap.h
+++ b/src/globalmeshingheap.h
@@ -271,9 +271,9 @@ public:
 
     auto mh = miniheapFor(ptr);
     if (likely(mh)) {
-      // .. bitmap get
+      auto result = mh->bitmapGet(type, ptr);
       mh->unref();
-      return 0;
+      return result;
     } else {
       internal::__mesh_assert_fail("TODO: bitmap on bigheap", __FILE__, __PRETTY_FUNCTION__, __LINE__, "");
     }
@@ -285,9 +285,9 @@ public:
 
     auto mh = miniheapFor(ptr);
     if (likely(mh)) {
-      // .. bitmap set
+      auto result = mh->bitmapSet(type, ptr);
       mh->unref();
-      return 0;
+      return result;
     } else {
       internal::__mesh_assert_fail("TODO: bitmap on bigheap", __FILE__, __PRETTY_FUNCTION__, __LINE__, "");
     }
@@ -299,9 +299,9 @@ public:
 
     auto mh = miniheapFor(ptr);
     if (likely(mh)) {
-      // .. bitmap clear
+      auto result = mh->bitmapClear(type, ptr);
       mh->unref();
-      return 0;
+      return result;
     } else {
       internal::__mesh_assert_fail("TODO: bitmap on bigheap", __FILE__, __PRETTY_FUNCTION__, __LINE__, "");
     }

--- a/src/globalmeshingheap.h
+++ b/src/globalmeshingheap.h
@@ -265,6 +265,48 @@ public:
     }
   }
 
+  int bitmapGet(enum mesh::BitType type, void *ptr) {
+    if (unlikely(ptr == nullptr))  // || internal::isMeshMarker(ptr))
+      return 0;
+
+    auto mh = miniheapFor(ptr);
+    if (likely(mh)) {
+      // .. bitmap get
+      mh->unref();
+      return 0;
+    } else {
+      internal::__mesh_assert_fail("TODO: bitmap on bigheap", __FILE__, __PRETTY_FUNCTION__, __LINE__, "");
+    }
+  }
+
+  int bitmapSet(enum mesh::BitType type, void *ptr) {
+    if (unlikely(ptr == nullptr))  // || internal::isMeshMarker(ptr))
+      return 0;
+
+    auto mh = miniheapFor(ptr);
+    if (likely(mh)) {
+      // .. bitmap set
+      mh->unref();
+      return 0;
+    } else {
+      internal::__mesh_assert_fail("TODO: bitmap on bigheap", __FILE__, __PRETTY_FUNCTION__, __LINE__, "");
+    }
+  }
+
+  int bitmapClear(enum mesh::BitType type, void *ptr) {
+    if (unlikely(ptr == nullptr))  // || internal::isMeshMarker(ptr))
+      return 0;
+
+    auto mh = miniheapFor(ptr);
+    if (likely(mh)) {
+      // .. bitmap clear
+      mh->unref();
+      return 0;
+    } else {
+      internal::__mesh_assert_fail("TODO: bitmap on bigheap", __FILE__, __PRETTY_FUNCTION__, __LINE__, "");
+    }
+  }
+
   int mallctl(const char *name, void *oldp, size_t *oldlenp, void *newp, size_t newlen) {
     std::shared_lock<std::shared_timed_mutex> sharedLock(_mhRWLock);
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -30,6 +30,15 @@ static inline constexpr size_t RoundUpToPage(size_t sz) {
   return HL::CPUInfo::PageSize * PageCount(sz);
 }
 
+// keep in-sync with the version in plasma/mesh.h
+enum BitType {
+  MESH_BIT_0,
+  MESH_BIT_1,
+  MESH_BIT_2,
+  MESH_BIT_3,
+  MESH_BIT_COUNT,
+};
+
 namespace internal {
 
 static const double MeshPeriodSecs = .1;

--- a/src/libmesh.cc
+++ b/src/libmesh.cc
@@ -142,7 +142,11 @@ int epoll_pwait(int __epfd, struct epoll_event *__events, int __maxevents, int _
   return mesh::runtime().epollPwait(__epfd, __events, __maxevents, __timeout, __ss);
 }
 
-  int mesh_bit_get(enum mesh::BitType type, void *ptr) {
+int mesh_in_bounds(void *ptr) {
+  return mesh::runtime().heap().inBounds(ptr);
+}
+
+int mesh_bit_get(enum mesh::BitType type, void *ptr) {
   return mesh::runtime().heap().bitmapGet(type, ptr);
 }
 

--- a/src/libmesh.cc
+++ b/src/libmesh.cc
@@ -141,4 +141,16 @@ int epoll_wait(int __epfd, struct epoll_event *__events, int __maxevents, int __
 int epoll_pwait(int __epfd, struct epoll_event *__events, int __maxevents, int __timeout, const __sigset_t *__ss) {
   return mesh::runtime().epollPwait(__epfd, __events, __maxevents, __timeout, __ss);
 }
+
+  int mesh_bit_get(enum mesh::BitType type, void *ptr) {
+  return mesh::runtime().heap().bitmapGet(type, ptr);
+}
+
+int mesh_bit_set(enum mesh::BitType type, void *ptr) {
+  return mesh::runtime().heap().bitmapSet(type, ptr);
+}
+
+int mesh_bit_clear(enum mesh::BitType type, void *ptr) {
+  return mesh::runtime().heap().bitmapClear(type, ptr);
+}
 }

--- a/src/meshable-arena.cc
+++ b/src/meshable-arena.cc
@@ -1,8 +1,8 @@
 // -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil -*-
 // Copyright 2017 University of Massachusetts, Amherst
 
-// #define USE_MEMFD 1
-#undef USE_MEMFD
+#define USE_MEMFD 1
+// #undef USE_MEMFD
 
 #ifdef USE_MEMFD
 #include <sys/syscall.h>
@@ -25,11 +25,9 @@ namespace mesh {
 
 static void *arenaInstance;
 
-#ifndef USE_MEMFD
 static const char *const TMP_DIRS[] = {
     "/dev/shm", "/tmp",
 };
-#endif
 
 MeshableArena::MeshableArena() : SuperHeap(), _bitmap{internal::ArenaSize / CPUInfo::PageSize} {
   d_assert(arenaInstance == nullptr);

--- a/src/meshable-arena.h
+++ b/src/meshable-arena.h
@@ -196,6 +196,7 @@ private:
   }
 
   int openSpanFile(size_t sz);
+  char *openSpanDir(int pid);
 
   // pointer must already have been checked by `contains()` for bounds
   size_t offsetFor(const void *ptr) const {
@@ -230,6 +231,12 @@ private:
   static void staticAfterForkChild();
 
   void exit() {
+    // FIXME: do this from the destructor, and test that destructor is
+    // called.  Also don't leak _spanDir
+    if (_spanDir != nullptr) {
+      rmdir(_spanDir);
+      _spanDir = nullptr;
+    }
   }
 
   void prepareForFork();
@@ -250,6 +257,7 @@ private:
 
   int _fd;
   int _forkPipe[2]{-1, -1};  // used for signaling during fork
+  char *_spanDir{nullptr};
 };
 }  // namespace mesh
 

--- a/src/miniheap.h
+++ b/src/miniheap.h
@@ -274,6 +274,66 @@ public:
     mesh::debug("\t%s\n", _bitmap.to_string().c_str());
   }
 
+  inline int bitmapGet(enum mesh::BitType type, void *ptr) {
+    const ssize_t off = getOff(ptr);
+    d_assert(off >= 0);
+
+    switch (type) {
+    case MESH_BIT_0:
+      return _bitmap0.isSet(off);
+    case MESH_BIT_1:
+      return _bitmap1.isSet(off);
+    case MESH_BIT_2:
+      return _bitmap2.isSet(off);
+    case MESH_BIT_3:
+      return _bitmap3.isSet(off);
+    default:
+      break;
+    }
+    d_assert(false);
+    return -1;
+  }
+
+  inline int bitmapSet(enum mesh::BitType type, void *ptr) {
+    const ssize_t off = getOff(ptr);
+    d_assert(off >= 0);
+
+    switch (type) {
+    case MESH_BIT_0:
+      return _bitmap0.tryToSet(off);
+    case MESH_BIT_1:
+      return _bitmap1.tryToSet(off);
+    case MESH_BIT_2:
+      return _bitmap2.tryToSet(off);
+    case MESH_BIT_3:
+      return _bitmap3.tryToSet(off);
+    default:
+      break;
+    }
+    d_assert(false);
+    return -1;
+  }
+
+  inline int bitmapClear(enum mesh::BitType type, void *ptr) {
+    const ssize_t off = getOff(ptr);
+    d_assert(off >= 0);
+
+    switch (type) {
+    case MESH_BIT_0:
+      return _bitmap0.unset(off);
+    case MESH_BIT_1:
+      return _bitmap1.unset(off);
+    case MESH_BIT_2:
+      return _bitmap2.unset(off);
+    case MESH_BIT_3:
+      return _bitmap3.unset(off);
+    default:
+      break;
+    }
+    d_assert(false);
+    return -1;
+  }
+
 protected:
   inline uintptr_t spanStart(void *ptr) const {
     const auto ptrval = reinterpret_cast<uintptr_t>(ptr);

--- a/src/miniheap.h
+++ b/src/miniheap.h
@@ -34,7 +34,11 @@ public:
         _span{reinterpret_cast<char *>(span)},
         _meshCount(1),
         _attached(true),
-        _bitmap(maxCount()) {
+        _bitmap(maxCount()),
+        _bitmap0(maxCount()),
+        _bitmap1(maxCount()),
+        _bitmap2(maxCount()),
+        _bitmap3(maxCount()) {
     if (!_span[0])
       abort();
 
@@ -329,12 +333,17 @@ protected:
   uint32_t _meshCount;// : 7;
   atomic<uint32_t> _attached;// : 1;
   internal::Bitmap _bitmap; // 16 bytes
+  internal::Bitmap _bitmap0; // 16 bytes
+  internal::Bitmap _bitmap1; // 16 bytes
+  internal::Bitmap _bitmap2; // 16 bytes
+  internal::Bitmap _bitmap3; // 16 bytes
 };
 
 typedef MiniHeapBase<> MiniHeap;
 
 static_assert(sizeof(mesh::internal::Bitmap) == 16, "Bitmap too big!");
-static_assert(sizeof(MiniHeap) == 96, "MiniHeap too big!");
+//static_assert(sizeof(MiniHeap) == 96, "MiniHeap too big!");
+static_assert(sizeof(MiniHeap) == 160, "MiniHeap too big!");
 //static_assert(sizeof(MiniHeap) == 80, "MiniHeap too big!");
 
 }  // namespace mesh

--- a/src/miniheap.h
+++ b/src/miniheap.h
@@ -274,7 +274,7 @@ public:
     mesh::debug("\t%s\n", _bitmap.to_string().c_str());
   }
 
-  inline int bitmapGet(enum mesh::BitType type, void *ptr) {
+  inline int bitmapGet(enum mesh::BitType type, void *ptr) const {
     const ssize_t off = getOff(ptr);
     d_assert(off >= 0);
 

--- a/src/mmapheap.h
+++ b/src/mmapheap.h
@@ -125,6 +125,14 @@ public:
     return entry->second;
   }
 
+  inline bool inBounds(void *ptr) const {
+    auto entry = _vmaMap.find(ptr);
+    if (unlikely(entry == _vmaMap.end())) {
+      return false;
+    }
+    return true;
+  }
+
   inline void free(void *ptr) {
     auto entry = _vmaMap.find(ptr);
     if (unlikely(entry == _vmaMap.end())) {

--- a/src/plasma/mesh.h
+++ b/src/plasma/mesh.h
@@ -21,6 +21,24 @@ int mesh_mallctl(const char *name, void *oldp, size_t *oldlenp, void *newp, size
 // returns the usable size of an allocation
 size_t mesh_usable_size(void *ptr);
 
+enum MeshBitType {
+  MESH_BIT_0,
+  MESH_BIT_1,
+  MESH_BIT_2,
+  MESH_BIT_3,
+  MESH_BIT_COUNT,
+};
+
+// Ruby has 4 bitmaps
+#define MESH_UNPROTECTED_BIT   MESH_BIT_0
+#define MESH_MARK_BIT          MESH_BIT_1
+#define MESH_UNCOLLECTABLE_BIT MESH_BIT_2
+#define MESH_MARKING_BIT       MESH_BIT_3
+
+int mesh_bit_get(enum MeshBitType type, void *ptr);
+int mesh_bit_set(enum MeshBitType type, void *ptr);
+int mesh_bit_clear(enum MeshBitType type, void *ptr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/plasma/mesh.h
+++ b/src/plasma/mesh.h
@@ -18,6 +18,9 @@ extern "C" {
 // allocator-related options.
 int mesh_mallctl(const char *name, void *oldp, size_t *oldlenp, void *newp, size_t newlen);
 
+// 0 if not in bounds, 1 if is.
+int mesh_in_bounds(void *ptr);
+
 // returns the usable size of an allocation
 size_t mesh_usable_size(void *ptr);
 
@@ -28,12 +31,6 @@ enum MeshBitType {
   MESH_BIT_3,
   MESH_BIT_COUNT,
 };
-
-// Ruby has 4 bitmaps
-#define MESH_UNPROTECTED_BIT   MESH_BIT_0
-#define MESH_MARK_BIT          MESH_BIT_1
-#define MESH_UNCOLLECTABLE_BIT MESH_BIT_2
-#define MESH_MARKING_BIT       MESH_BIT_3
 
 int mesh_bit_get(enum MeshBitType type, void *ptr);
 int mesh_bit_set(enum MeshBitType type, void *ptr);


### PR DESCRIPTION
The Ruby VM implements a classic mark/sweep GC.  This GC is tightly integrated with requesting batches of objects at a time from `malloc`.  Ruby basically asks for a 4k page, carves out some space for metadata + bitmaps, and then divides the rest up into 40-byte `RVALUE` objects.  I think we just want our allocator to be able to provide these additional bitmaps for Ruby (or other, similar applications like `cpython`).

This current version is kludgey, and I think we want something more dynamic, but its a start.