### PR TITLE
invert freelist reference, significantly faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PREFIX = /usr
 
 ARCH             = x86_64
 
-COMMON_SRCS      = src/runtime.cc src/real.cc src/meshing.cc src/meshable-arena.cc src/d_assert.cc
+COMMON_SRCS      = src/thread_local_heap.cc src/global_heap.cc src/runtime.cc src/real.cc src/meshing.cc src/meshable-arena.cc src/d_assert.cc
 
 LIB_SRCS         = $(COMMON_SRCS) src/libmesh.cc
 LIB_OBJS         = $(addprefix build/,$(patsubst %.c,%.o,$(patsubst %.S,%.o,$(LIB_SRCS:.cc=.o))))

--- a/src/binnedtracker.h
+++ b/src/binnedtracker.h
@@ -20,7 +20,7 @@
 
 namespace mesh {
 
-template <typename MiniHeap, size_t BinCount = 4, size_t MaxEmpty = 128>
+template <typename MiniHeap>
 class BinnedTracker {
 private:
   DISALLOW_COPY_AND_ASSIGN(BinnedTracker);
@@ -59,7 +59,7 @@ public:
     const size_t off = distribution(_prng);
 
     size_t count = 0;
-    for (size_t i = 0; i < BinCount; i++) {
+    for (size_t i = 0; i < kBinnedTrackerBinCount; i++) {
       count += _partial[i].size();
       if (off < count)
         return popRandomLocked(_partial[i]);
@@ -72,7 +72,7 @@ public:
   MiniHeap *selectForReuse() {
     std::lock_guard<std::mutex> lock(_mutex);
 
-    for (int i = BinCount - 1; i >= 0; i--) {
+    for (int i = kBinnedTrackerBinCount - 1; i >= 0; i--) {
       while (_partial[i].size() > 0) {
         auto mh = popRandomLocked(_partial[i]);
         // this can happen because in use count is updated outside the
@@ -94,9 +94,9 @@ public:
     internal::vector<MiniHeap *> bucket{};
 
     // consider all of our partially filled miniheaps
-    for (size_t i = 0; i < BinCount; i++) {
+    for (size_t i = 0; i < kBinnedTrackerBinCount; i++) {
       const auto partial = _partial[i];
-      if (i == BinCount/2 + 1 && bucket.size() == 0) {
+      if (i == kBinnedTrackerBinCount/2 + 1 && bucket.size() == 0) {
         break;
       }
       for (size_t j = 0; j < partial.size(); j++) {
@@ -139,7 +139,7 @@ public:
 
       move(getBin(newBinId), getBin(oldBinId), mh, newBinId);
 
-      if (newBinId != internal::BinToken::FlagEmpty || _empty.size() < MaxEmpty)
+      if (newBinId != internal::BinToken::FlagEmpty || _empty.size() < kBinnedTrackerMaxEmpty)
         return false;
     }
 
@@ -180,7 +180,7 @@ public:
         sz += _full[i]->inUseCount();
     }
 
-    for (size_t i = 0; i < BinCount; i++) {
+    for (size_t i = 0; i < kBinnedTrackerBinCount; i++) {
       auto partial = _partial[i];
       for (size_t j = 0; j < partial.size(); j++) {
         MiniHeap *mh = partial[j];
@@ -210,7 +210,7 @@ public:
 
   size_t partialSizeLocked() const {
     size_t sz = 0;
-    for (size_t i = 0; i < BinCount; i++) {
+    for (size_t i = 0; i < kBinnedTrackerBinCount; i++) {
       sz += _partial[i].size();
     }
     return sz;
@@ -224,7 +224,7 @@ public:
         _full[i]->printOccupancy();
     }
 
-    for (size_t i = 0; i < BinCount; i++) {
+    for (size_t i = 0; i < kBinnedTrackerBinCount; i++) {
       auto partial = _partial[i];
       for (size_t j = 0; j < partial.size(); j++) {
         MiniHeap *mh = partial[j];
@@ -258,7 +258,7 @@ public:
       }
     }
 
-    for (size_t i = 0; i < BinCount; i++) {
+    for (size_t i = 0; i < kBinnedTrackerBinCount; i++) {
       auto partial = _partial[i];
       for (size_t j = 0; j < partial.size(); j++) {
         MiniHeap *mh = partial[j];
@@ -371,7 +371,7 @@ private:
     } else if (inUseCount == 0) {
       return internal::BinToken::FlagEmpty;
     } else {
-      return (inUseCount * BinCount) / _objectCount;
+      return (inUseCount * kBinnedTrackerBinCount) / _objectCount;
     }
   }
 
@@ -386,7 +386,7 @@ private:
   }
 
   internal::vector<MiniHeap *> _full;
-  internal::vector<MiniHeap *> _partial[BinCount];
+  internal::vector<MiniHeap *> _partial[kBinnedTrackerBinCount];
   internal::vector<MiniHeap *> _empty;
 
   atomic_size_t _objectSize{0};

--- a/src/binnedtracker.h
+++ b/src/binnedtracker.h
@@ -96,7 +96,7 @@ public:
     // consider all of our partially filled miniheaps
     for (size_t i = 0; i < kBinnedTrackerBinCount; i++) {
       const auto partial = _partial[i];
-      if (i == kBinnedTrackerBinCount/2 + 1 && bucket.size() == 0) {
+      if (i == kBinnedTrackerBinCount / 2 + 1 && bucket.size() == 0) {
         break;
       }
       for (size_t j = 0; j < partial.size(); j++) {

--- a/src/common.h
+++ b/src/common.h
@@ -41,7 +41,6 @@ static const double kMeshPeriodSecs = .1;
 
 // controls aspects of miniheaps
 static constexpr size_t kMaxMeshes = 4;
-static constexpr bool kSlowButAccurateRandom = false;
 
 // static constexpr size_t ArenaSize = 1UL << 35;        // 32 GB
 static constexpr size_t kArenaSize = 1UL << 30;       // 32 GB

--- a/src/common.h
+++ b/src/common.h
@@ -30,13 +30,16 @@ static constexpr int kPageSize = 4096;
 static constexpr int kNumBins = 25;  // 16Kb max object size
 static constexpr int kDefaultMeshPeriod = 10000;
 
+// ensures we amortize the cost of going to the global heap enough
 static constexpr size_t kMinStringLen = 8;
 
+// shuffle freelist features
 static constexpr size_t kMaxFreelistLength = sizeof(uint8_t) << 8;  // 256
 static constexpr bool kEnableShuffleFreelist = true;
 
 static const double kMeshPeriodSecs = .1;
 
+// controls aspects of miniheaps
 static constexpr size_t kMaxMeshes = 4;
 static constexpr bool kSlowButAccurateRandom = false;
 
@@ -45,6 +48,10 @@ static constexpr size_t kArenaSize = 1UL << 30;       // 32 GB
 static constexpr size_t kAltStackSize = 16 * 1024UL;  // 16k sigaltstacks
 #define SIGQUIESCE (SIGRTMIN + 7)
 #define SIGDUMP (SIGRTMIN + 8)
+
+// BinnedTracker
+static constexpr size_t kBinnedTrackerBinCount = 4;
+static constexpr size_t kBinnedTrackerMaxEmpty = 128;
 };  // namespace mesh
 
 using std::condition_variable;

--- a/src/fragmenter.cc
+++ b/src/fragmenter.cc
@@ -1,13 +1,13 @@
 // -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil -*-
 // Copyright 2017 University of Massachusetts, Amherst
 
+#include <unistd.h>
 #include <cstdio>
 #include <cstring>
 #include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <unistd.h>
 
 #include <gflags/gflags.h>
 
@@ -45,7 +45,7 @@ void NOINLINE basic_fragment(int64_t n, size_t m_total) {
   size_t m_usage = 0;  // S_t in the paper
 
   const size_t ptr_table_len = m_total / (ci * n);
-  //fprintf(stdout, "ptr_table_len: %zu\n", ptr_table_len);
+  // fprintf(stdout, "ptr_table_len: %zu\n", ptr_table_len);
   volatile char *volatile *ptr_table =
       reinterpret_cast<volatile char *volatile *>(bench_alloc(ptr_table_len * sizeof(char *)));
 
@@ -58,7 +58,7 @@ void NOINLINE basic_fragment(int64_t n, size_t m_total) {
     // number of allocation pairs in this iteration
     const size_t pi = m_avail / (2 * ci * n);
 
-    //fprintf(stderr, "i:%4zu, ci:%5zu, n:%5zu, pi:%7zu (osize:%5zu)\n", i, ci, n, pi, ci * n);
+    // fprintf(stderr, "i:%4zu, ci:%5zu, n:%5zu, pi:%7zu (osize:%5zu)\n", i, ci, n, pi, ci * n);
 
     // allocate two objects
     for (size_t k = 0; k < pi; k++) {
@@ -100,7 +100,7 @@ int main(int argc, char *argv[]) {
 
   // print_self_rss();
 
-  //sleep(700);
+  // sleep(700);
 
   return 0;
 }

--- a/src/freelist.h
+++ b/src/freelist.h
@@ -37,22 +37,20 @@ private:
   DISALLOW_COPY_AND_ASSIGN(Freelist);
 
 public:
-  Freelist(size_t objectCount) : _maxCount(objectCount) {
-    d_assert_msg(objectCount <= kMaxFreelistLength, "objCount? %zu <= %zu", objectCount, kMaxFreelistLength);
-    d_assert(_maxCount == objectCount);
+  Freelist() {
   }
 
   ~Freelist() {
     detach();
   }
 
-  void init(mt19937_64 &prng, MWC &fastPrng, internal::Bitmap &bitmap) {
-    const size_t objectCount = maxCount();
+  void init(size_t objectCount, MWC &fastPrng, internal::Bitmap &bitmap) {
+    _maxCount = objectCount;
+    d_assert_msg(objectCount <= kMaxFreelistLength, "objCount? %zu <= %zu", objectCount, kMaxFreelistLength);
+    d_assert(_maxCount == objectCount);
     const size_t listSize = objectCount * sizeof(uint8_t);
 
     _off = bitmap.inUseCount();
-
-    _list = reinterpret_cast<uint8_t *>(mesh::internal::Heap().malloc(listSize));
 
     for (size_t i = 0, off = _off; i < objectCount; i++) {
       // if we were passed in a bitmap and the current object is
@@ -68,23 +66,20 @@ public:
     }
 
     if (kEnableShuffleFreelist) {
-      // mwcShuffle(&_list[0], &_list[objectCount], fastPrng);
-      std::shuffle(&_list[_off], &_list[objectCount], prng);
+      mwcShuffle(&_list[0], &_list[objectCount], fastPrng);
+      // std::shuffle(&_list[_off], &_list[objectCount], prng);
     }
   }
 
   void detach() {
-    auto list = _list;
-    _list = nullptr;
+    // auto list = _list;
+    // _list = nullptr;
     atomic_thread_fence(memory_order_seq_cst);
-    mesh::internal::Heap().free(list);
+    // mesh::internal::Heap().free(list);
   }
 
-  inline bool isNonNullExhausted() const {
-    return _off >= _maxCount;
-  }
   inline bool isExhausted() const {
-    return _list == nullptr || isNonNullExhausted();
+    return _off >= _maxCount;
   }
 
   inline size_t maxCount() const {
@@ -98,41 +93,34 @@ public:
 
   // Pushing an element onto the freelist does a round of the
   // Fisher-Yates shuffle.
-  inline void push(size_t freedOff, mt19937_64 &prng, MWC &mwc) {
+  inline void push(MWC &prng, size_t freedOff) {
     d_assert(_off > 0);  // we must have at least 1 free space in the list
     _list[--_off] = freedOff;
 
     if (kEnableShuffleFreelist) {
-      size_t swapOff;
-      if (kSlowButAccurateRandom) {
-        // endpoint is _inclusive_, so we subtract 1 from maxCount since
-        // we're dealing with 0-indexed offsets
-        std::uniform_int_distribution<size_t> distribution(_off, maxCount() - 1);
-
-        swapOff = distribution(prng);
-      } else {
-        swapOff = mwc.inRange(_off, maxCount() - 1);
-      }
+      size_t swapOff = prng.inRange(_off, maxCount() - 1);
 
       std::swap(_list[_off], _list[swapOff]);
     }
   }
 
-  inline size_t pop(bool &isExhausted) {
+  inline size_t pop(bool &exhausted) {
     d_assert(_off >= 0 && static_cast<uint16_t>(_off) < _maxCount);
     auto allocOff = _list[_off++];
 
-    isExhausted = isNonNullExhausted();
+    exhausted = isExhausted();
 
     return allocOff;
   }
 
 private:
-  uint8_t *_list{nullptr};
-  const uint16_t _maxCount;
-  // FIXME: we can use a uint8_t here if we encode "overflowed" as _list == nullptr
+  uint16_t _maxCount{0};
   uint16_t _off{0};
+  uint8_t _list[kMaxFreelistLength];
+  uint8_t __padding[60];
 };
+
+static_assert(HL::gcd<sizeof(Freelist), CACHELINE_SIZE>::value == CACHELINE_SIZE, "Freelist not multiple of cacheline size!");
 }  // namespace mesh
 
 #endif  // MESH__FREELIST_H

--- a/src/global_heap.cc
+++ b/src/global_heap.cc
@@ -1,0 +1,4 @@
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil -*-
+// Copyright 2017 University of Massachusetts, Amherst
+
+#include "global_heap.h"

--- a/src/global_heap.h
+++ b/src/global_heap.h
@@ -90,9 +90,6 @@ public:
     // check our bins for a miniheap to reuse
     MiniHeap *existing = _littleheaps[sizeClass].selectForReuse();
     if (existing != nullptr) {
-      existing->reattach(_prng, _fastPrng);  // populate freelist, set attached bit
-      d_assert(existing->isAttached());
-      // TODO: check that metadata is right?
       return existing;
     }
 
@@ -115,7 +112,7 @@ public:
 
     // if (spanSize > 4096)
     //   mesh::debug("spana %p(%zu) %p (%zu)", span, spanSize, buf, objectSize);
-    MiniHeap *mh = new (buf) MiniHeap(span, nObjects, sizeMax, _prng, _fastPrng, spanSize);
+    MiniHeap *mh = new (buf) MiniHeap(span, nObjects, sizeMax, _fastPrng, spanSize);
     Super::assoc(span, mh, nPages);
 
     trackMiniheapLocked(sizeClass, mh);

--- a/src/global_heap.h
+++ b/src/global_heap.h
@@ -1,8 +1,9 @@
 // -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil -*-
 // Copyright 2017 University of Massachusetts, Amherst
 
-#ifndef MESH__GLOBALMESHINGHEAP_H
-#define MESH__GLOBALMESHINGHEAP_H
+#pragma once
+#ifndef MESH__GLOBAL_HEAP_H
+#define MESH__GLOBAL_HEAP_H
 
 #include <algorithm>
 #include <mutex>
@@ -530,4 +531,4 @@ protected:
 };
 }  // namespace mesh
 
-#endif  // MESH__GLOBALMESHINGHEAP_H
+#endif  // MESH__GLOBAL_HEAP_H

--- a/src/global_heap.h
+++ b/src/global_heap.h
@@ -9,13 +9,13 @@
 #include <mutex>
 #include <shared_mutex>
 
-#include "heaplayers.h"
-
 #include "binnedtracker.h"
 #include "internal.h"
 #include "meshable-arena.h"
 #include "meshing.h"
 #include "miniheap.h"
+
+#include "heaplayers.h"
 
 using namespace HL;
 

--- a/src/global_heap.h
+++ b/src/global_heap.h
@@ -438,7 +438,6 @@ public:
 
 protected:
   void performMeshing(internal::vector<std::pair<MiniHeap *, MiniHeap *>> &mergeSets) {
-
     for (auto &mergeSet : mergeSets) {
       // merge _into_ the one with a larger mesh count, potentiall
       // swapping the order of the pair

--- a/src/internal.h
+++ b/src/internal.h
@@ -125,6 +125,10 @@ typename Map::iterator greatest_leq(Map &m, typename Map::key_type const &k) {
 
 typedef Bitmap<Heap> Bitmap;
 
+// BinTokens are stored on MiniHeaps and used by the BinTracker to
+// store occupancy metadata.  They are opaque to the MiniHeap, but
+// storing the BinTracker's metadata on the MiniHeap saves a bunch of
+// internal allocations and indirections.
 class BinToken {
 public:
   typedef uint32_t Size;

--- a/src/meshable-arena.cc
+++ b/src/meshable-arena.cc
@@ -26,7 +26,8 @@ namespace mesh {
 static void *arenaInstance;
 
 static const char *const TMP_DIRS[] = {
-    "/dev/shm", "/tmp",
+    "/dev/shm",
+    "/tmp",
 };
 
 MeshableArena::MeshableArena() : SuperHeap(), _bitmap{kArenaSize / CPUInfo::PageSize} {
@@ -93,12 +94,11 @@ void MeshableArena::finalizeMesh(void *keep, void *remove, size_t sz) {
     setMetadata(removeOff + i, internal::PageType::Meshed | getMetadataPtr(keepOff));
   }
 
-
   void *ptr = mmap(remove, sz, HL_MMAP_PROTECTION_MASK, MAP_SHARED | MAP_FIXED, _fd, keepOff * CPUInfo::PageSize);
   hard_assert_msg(ptr != MAP_FAILED, "mesh remap failed: %d", errno);
   freePhys(remove, sz);
 
-  mprotect(remove, sz, PROT_READ|PROT_WRITE);
+  mprotect(remove, sz, PROT_READ | PROT_WRITE);
 }
 
 #ifdef USE_MEMFD

--- a/src/meshable-arena.h
+++ b/src/meshable-arena.h
@@ -84,7 +84,7 @@ public:
         // if one of the pages we need is already in use, bump our
         // offset into the page index up and try again
         if (_bitmap.isSet(firstOff + i)) {
-          _bitmap.unset(firstOff); // don't 'leak' this empty page
+          _bitmap.unset(firstOff);  // don't 'leak' this empty page
           firstOff += i + 1;
           found = false;
           break;
@@ -105,7 +105,7 @@ public:
         debug("hard assertion failue");
         abort();
       }
-      d_assert(getMetadataFlags(firstOff+i) == 0 && getMetadataPtr(firstOff+i) == 0);
+      d_assert(getMetadataFlags(firstOff + i) == 0 && getMetadataPtr(firstOff + i) == 0);
       setMetadata(firstOff + i, internal::PageType::Identity);
     }
 
@@ -164,7 +164,7 @@ public:
     // under the MH writer-lock in global heap
     uintptr_t mh = reinterpret_cast<uintptr_t>(miniheap);
     for (size_t i = 0; i < pageCount; i++) {
-      setMetadata(off+i, mh | getMetadataFlags(off));
+      setMetadata(off + i, mh | getMetadataFlags(off));
     }
 
     // mesh::debug("assoc %p(%zu) %p | %u", span, off, miniheap, getMetadataFlags(off));

--- a/src/meshing.h
+++ b/src/meshing.h
@@ -169,7 +169,6 @@ inline CutoffTable *generateCutoffs(const size_t len, const double cutoffPercent
 template <typename T>
 inline void halfSplit(mt19937_64 &prng, BinnedTracker<T> &miniheaps, internal::vector<T *> &left,
                       internal::vector<T *> &right) noexcept {
-
   internal::vector<T *> bucket = miniheaps.meshingCandidates(OccupancyCutoff);
 
   std::shuffle(bucket.begin(), bucket.end(), prng);

--- a/src/meshing_benchmark.cc
+++ b/src/meshing_benchmark.cc
@@ -15,12 +15,12 @@
 #include "bitmap.h"
 #include "meshing.h"
 
-using std::vector;
+using mesh::Bitmap;
+using std::make_unique;
+using std::stoi;
 using std::string;
 using std::unique_ptr;
-using std::make_unique;
-using mesh::Bitmap;
-using std::stoi;
+using std::vector;
 
 typedef std::basic_string<char, std::char_traits<char>, STLAllocator<char, MallocHeap>> internal_string;
 

--- a/src/miniheap.h
+++ b/src/miniheap.h
@@ -27,8 +27,7 @@ private:
   DISALLOW_COPY_AND_ASSIGN(MiniHeap);
 
 public:
-  MiniHeap(void *span, size_t objectCount, size_t objectSize, mt19937_64 &prng, MWC &fastPrng,
-               size_t expectedSpanSize)
+  MiniHeap(void *span, size_t objectCount, size_t objectSize, mt19937_64 &prng, MWC &fastPrng, size_t expectedSpanSize)
       : _freelist{objectCount},
         _attached(pthread_self()),
         _bitmap(maxCount()),
@@ -424,7 +423,7 @@ protected:
 
   Freelist _freelist;
   atomic<pthread_t> _attached;  // FIXME: this adds 4 bytes of additional padding
-  internal::Bitmap _bitmap;    // 16 bytes
+  internal::Bitmap _bitmap;     // 16 bytes
 
   const uint32_t _objectSize;
   const uint32_t _spanSize;
@@ -434,7 +433,7 @@ protected:
   uint32_t _inUseCount{0};  // 60
 
   mutable uint32_t _refCount{0};
-  uint32_t _meshCount;         // : 7;
+  uint32_t _meshCount;  // : 7;
 #ifdef MESH_EXTRA_BITS
   internal::Bitmap _bitmap0;  // 16 bytes
   internal::Bitmap _bitmap1;  // 16 bytes

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -31,8 +31,6 @@ const int32_t SizeMap::class_to_size_[kClassSizesMax] = {
 // const internal::BinToken::Size internal::BinToken::FlagEmpty = numeric_limits<uint32_t>::max() - 2;
 // const internal::BinToken::Size internal::BinToken::FlagNoOff = numeric_limits<uint32_t>::max();
 
-__thread ThreadLocalHeap::ThreadLocalData ThreadLocalHeap::_threadLocalData ATTR_INITIAL_EXEC CACHELINE_ALIGNED;
-
 STLAllocator<char, internal::Heap> internal::allocator{};
 
 size_t internal::measurePssKiB() {

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -12,7 +12,7 @@
 
 #include "real.h"
 
-#include "globalmeshingheap.h"
+#include "global_heap.h"
 #include "lockedheap.h"
 #include "mmapheap.h"
 

--- a/src/test/local-alloc.c
+++ b/src/test/local-alloc.c
@@ -7,7 +7,7 @@
 volatile char *volatile var;
 
 int main() {
-  for (size_t i = 0; i < 20000000; i++) {
+  for (size_t i = 0; i < 200000000; i++) {
     var = malloc(SZ);
     memset((char *)var, 0, SZ);
     free((void *)var);

--- a/src/thread_local_heap.cc
+++ b/src/thread_local_heap.cc
@@ -1,0 +1,19 @@
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil -*-
+// Copyright 2017 University of Massachusetts, Amherst
+
+#include "thread_local_heap.h"
+
+namespace mesh {
+
+__thread ThreadLocalHeap::ThreadLocalData ThreadLocalHeap::_threadLocalData ATTR_INITIAL_EXEC CACHELINE_ALIGNED;
+
+ThreadLocalHeap *ThreadLocalHeap::GetHeap() {
+  auto heap = GetFastPathHeap();
+  if (heap == nullptr) {
+    heap = CreateThreadLocalHeap();
+    _threadLocalData.fastpathHeap = heap;
+  }
+  return heap;
+}
+
+};  // namespace mesh

--- a/src/thread_local_heap.h
+++ b/src/thread_local_heap.h
@@ -41,6 +41,10 @@ public:
       : _maxObjectSize(SizeMap::ByteSizeForClass(kNumBins - 1)),
         _prng(internal::seed(), internal::seed()),
         _global(global) {
+    // start at 1, becuase 0 is an unused '0' size class
+    for (size_t i = 1; i < kNumBins; i++) {
+      _freelist[i].setObjectSize(SizeMap::ByteSizeForClass(i));
+    }
     d_assert(_global != nullptr);
   }
 

--- a/src/thread_local_heap.h
+++ b/src/thread_local_heap.h
@@ -77,15 +77,6 @@ public:
       d_assert(_current[sizeClass] == mh);
     }
 
-    // if (unlikely(!mh->isAttached() || mh->isExhausted())) {
-    //   int attached = mh->isAttached();
-    //   int exhausted = mh->isExhausted();
-    //   mesh::debug("LocalHeap(sz: %zu): expecting failure %d %d (%zu/%zu)", sz, attached, exhausted, sizeMax,
-    //   mh->objectSize());
-    //   // mh->dumpDebug();
-    //   // abort();
-    // }
-
     bool isExhausted = false;
     void *ptr = mh->malloc(isExhausted);
     if (unlikely(isExhausted)) {

--- a/src/thread_local_heap.h
+++ b/src/thread_local_heap.h
@@ -94,7 +94,7 @@ public:
 
   inline void ATTRIBUTE_ALWAYS_INLINE free(void *ptr) {
     if (unlikely(ptr == nullptr))
-        return;
+      return;
 
     if (likely(_last != nullptr && _last->contains(ptr))) {
       _last->localFree(ptr, _prng, _mwc);

--- a/src/unit/mesh.cc
+++ b/src/unit/mesh.cc
@@ -20,13 +20,19 @@ static inline void note(const char *note) {
 }
 
 static void meshTest(bool invert) {
+  MWC prng(internal::seed(), internal::seed());
   GlobalHeap &gheap = runtime().heap();
 
   ASSERT_EQ(gheap.getAllocatedMiniheapCount(), 0);
 
+  Freelist f1;
+  Freelist f2;
+
   // allocate two miniheaps for the same object size from our global heap
   MiniHeap *mh1 = gheap.allocMiniheap(StrLen);
   MiniHeap *mh2 = gheap.allocMiniheap(StrLen);
+  mh1->reattach(f1, prng);
+  mh2->reattach(f2, prng);
 
   ASSERT_EQ(gheap.getAllocatedMiniheapCount(), 2);
 
@@ -42,8 +48,8 @@ static void meshTest(bool invert) {
   ASSERT_TRUE(s1 != nullptr);
   ASSERT_TRUE(s2 != nullptr);
 
-  mh1->freeEntireFreelistExcept(s1);
-  mh2->freeEntireFreelistExcept(s2);
+  mh1->freeEntireFreelistExcept(f1, s1);
+  mh2->freeEntireFreelistExcept(f2, s2);
 
   // fill in the strings, set the trailing null byte
   memset(s1, 'A', StrLen);

--- a/src/unit/mesh.cc
+++ b/src/unit/mesh.cc
@@ -20,19 +20,13 @@ static inline void note(const char *note) {
 }
 
 static void meshTest(bool invert) {
-  MWC prng(internal::seed(), internal::seed());
   GlobalHeap &gheap = runtime().heap();
 
   ASSERT_EQ(gheap.getAllocatedMiniheapCount(), 0);
 
-  Freelist f1;
-  Freelist f2;
-
   // allocate two miniheaps for the same object size from our global heap
   MiniHeap *mh1 = gheap.allocMiniheap(StrLen);
   MiniHeap *mh2 = gheap.allocMiniheap(StrLen);
-  mh1->reattach(f1, prng);
-  mh2->reattach(f2, prng);
 
   ASSERT_EQ(gheap.getAllocatedMiniheapCount(), 2);
 
@@ -42,14 +36,11 @@ static void meshTest(bool invert) {
   ASSERT_EQ(mh1->maxCount(), ObjCount);
 
   // allocate two c strings, one from each miniheap at different offsets
-  char *s1 = reinterpret_cast<char *>(mh1->mallocAt(0));
-  char *s2 = reinterpret_cast<char *>(mh2->mallocAt(ObjCount - 1));
+  char *s1 = reinterpret_cast<char *>(mh1->mallocAtWithBitmap(0));
+  char *s2 = reinterpret_cast<char *>(mh2->mallocAtWithBitmap(ObjCount - 1));
 
   ASSERT_TRUE(s1 != nullptr);
   ASSERT_TRUE(s2 != nullptr);
-
-  mh1->freeEntireFreelistExcept(f1, s1);
-  mh2->freeEntireFreelistExcept(f2, s2);
 
   // fill in the strings, set the trailing null byte
   memset(s1, 'A', StrLen);

--- a/src/unit/mprot_mesh.cc
+++ b/src/unit/mprot_mesh.cc
@@ -13,6 +13,7 @@
 
 #include "internal.h"
 #include "runtime.h"
+#include "freelist.h"
 
 using namespace std;
 using namespace mesh;
@@ -53,19 +54,15 @@ static inline void note(const char *note) {
 }
 
 static void meshTestConcurrentWrite(bool invert) {
-  MWC prng(internal::seed(), internal::seed());
   GlobalHeap &gheap = runtime().heap();
 
   ASSERT_EQ(gheap.getAllocatedMiniheapCount(), 0);
 
-  Freelist f1;
-  Freelist f2;
-
   // allocate two miniheaps for the same object size from our global heap
   MiniHeap *mh1 = gheap.allocMiniheap(StrLen);
   MiniHeap *mh2 = gheap.allocMiniheap(StrLen);
-  mh1->reattach(f1, prng);
-  mh2->reattach(f2, prng);
+  mh1->reattach(0);
+  mh2->reattach(0);
 
   ASSERT_EQ(gheap.getAllocatedMiniheapCount(), 2);
 
@@ -75,14 +72,11 @@ static void meshTestConcurrentWrite(bool invert) {
   ASSERT_EQ(mh1->maxCount(), ObjCount);
 
   // allocate two c strings, one from each miniheap at different offsets
-  s1 = reinterpret_cast<char *>(mh1->mallocAt(0));
-  s2 = reinterpret_cast<char *>(mh2->mallocAt(ObjCount - 1));
+  s1 = reinterpret_cast<char *>(mh1->mallocAtWithBitmap(0));
+  s2 = reinterpret_cast<char *>(mh2->mallocAtWithBitmap(ObjCount - 1));
 
   ASSERT_TRUE(s1 != nullptr);
   ASSERT_TRUE(s2 != nullptr);
-
-  mh1->freeEntireFreelistExcept(f1, s1);
-  mh2->freeEntireFreelistExcept(f2, s2);
 
   // fill in the strings, set the trailing null byte
   memset(s1, 'A', StrLen);

--- a/src/unit/mprot_mesh.cc
+++ b/src/unit/mprot_mesh.cc
@@ -53,13 +53,19 @@ static inline void note(const char *note) {
 }
 
 static void meshTestConcurrentWrite(bool invert) {
+  MWC prng(internal::seed(), internal::seed());
   GlobalHeap &gheap = runtime().heap();
 
   ASSERT_EQ(gheap.getAllocatedMiniheapCount(), 0);
 
+  Freelist f1;
+  Freelist f2;
+
   // allocate two miniheaps for the same object size from our global heap
   MiniHeap *mh1 = gheap.allocMiniheap(StrLen);
   MiniHeap *mh2 = gheap.allocMiniheap(StrLen);
+  mh1->reattach(f1, prng);
+  mh2->reattach(f2, prng);
 
   ASSERT_EQ(gheap.getAllocatedMiniheapCount(), 2);
 
@@ -75,8 +81,8 @@ static void meshTestConcurrentWrite(bool invert) {
   ASSERT_TRUE(s1 != nullptr);
   ASSERT_TRUE(s2 != nullptr);
 
-  mh1->freeEntireFreelistExcept(s1);
-  mh2->freeEntireFreelistExcept(s2);
+  mh1->freeEntireFreelistExcept(f1, s1);
+  mh2->freeEntireFreelistExcept(f2, s2);
 
   // fill in the strings, set the trailing null byte
   memset(s1, 'A', StrLen);


### PR DESCRIPTION
Instead of a miniheap referencing a freelist, have the thread-local heap have a set of freelists that reference miniheaps.