### PR TITLE
Fix warning: comparison of integers of different signs

### DIFF
--- a/src/unit/alignment.cc
+++ b/src/unit/alignment.cc
@@ -29,7 +29,7 @@ TEST(Alignment, NaturalAlignment) {
           logged = true;
         }
         const auto ptrval = reinterpret_cast<uintptr_t>(ptr);
-        ASSERT_EQ(ptrval % alignment, 0);
+        ASSERT_EQ(ptrval % alignment, 0UL);
         ptrs[i] = ptr;
       }
       for (size_t i = 0; i <= 256; i++) {


### PR DESCRIPTION
This fixes this warning on macOS:

```
In file included from src/unit/alignment.cc:8:
src/vendor/googletest/googletest/include/gtest/gtest.h:1466:11: warning: comparison of integers of different signs: 'const unsigned long' and 'const int' [-Wsign-compare]
  if (lhs == rhs) {
      ~~~ ^  ~~~
src/vendor/googletest/googletest/include/gtest/gtest.h:1494:12: note: in instantiation of function template specialization 'testing::internal::CmpHelperEQ<unsigned long, int>' requested here
    return CmpHelperEQ(lhs_expression, rhs_expression, lhs, rhs);
           ^
src/unit/alignment.cc:32:9: note: in instantiation of function template specialization 'testing::internal::EqHelper<false>::Compare<unsigned long, int>' requested here
        ASSERT_EQ(ptrval % alignment, 0);
        ^
src/vendor/googletest/googletest/include/gtest/gtest.h:2028:32: note: expanded from macro 'ASSERT_EQ'
# define ASSERT_EQ(val1, val2) GTEST_ASSERT_EQ(val1, val2)
                               ^
src/vendor/googletest/googletest/include/gtest/gtest.h:2011:63: note: expanded from macro 'GTEST_ASSERT_EQ'
                      EqHelper<GTEST_IS_NULL_LITERAL_(val1)>::Compare, \
                                                              ^
```
