### PR TITLE
Implement gettid for macOS.

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -34,6 +34,13 @@ inline pid_t gettid(void) {
   return syscall(__NR_gettid);
 }
 #endif
+#ifdef __APPLE__
+inline pid_t gettid(void) {
+  uint64_t tid;
+  pthread_threadid_np(NULL, &tid);
+  return static_cast<uint32_t>(tid);
+}
+#endif
 
 namespace mesh {
 


### PR DESCRIPTION
This isn't exactly correct since `pid_t` on macOS is a 32 bit value, but the thread ID can be 64 bit. This might matter for the value of `_current` in the thread local heap, but I'm not sure.