### PR TITLE
.gitignore: Ignore libmesh.dylib.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 *.d
+*.dylib
 *.o
 *.so
 *.pyc


### PR DESCRIPTION
Since shared objects on macOS use .dylib instead of .so, we need
to ignore *.dylib as well.