### PR TITLE
Small changes to get build working on Ubuntu 16.

### DIFF
--- a/src/cheap_heap.h
+++ b/src/cheap_heap.h
@@ -121,7 +121,7 @@ public:
     return ptrFromOffset(off);
   }
 
-  constexpr size_t getSize(void *ptr) const {
+  size_t getSize(void *ptr) const {
     return _allocSize;
   }
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -98,7 +98,7 @@ struct Span {
   Span(const Span &rhs) : offset(rhs.offset), length(rhs.length) {
   }
 
-  constexpr Span &operator=(const Span &rhs) {
+  Span &operator=(const Span &rhs) {
     offset = rhs.offset;
     length = rhs.length;
     return *this;

--- a/src/libmesh.cc
+++ b/src/libmesh.cc
@@ -190,18 +190,18 @@ void MESH_EXPORT xxmalloc_unlock(void) {
   mesh::runtime().unlock();
 }
 
-int MESH_EXPORT sigaction(int signum, const struct sigaction *act, struct sigaction *oldact) {
+int MESH_EXPORT sigaction(int signum, const struct sigaction *act, struct sigaction *oldact) throw() {
   return mesh::runtime().sigaction(signum, act, oldact);
 }
 
-int MESH_EXPORT sigprocmask(int how, const sigset_t *set, sigset_t *oldset) {
+int MESH_EXPORT sigprocmask(int how, const sigset_t *set, sigset_t *oldset) throw() {
   return mesh::runtime().sigprocmask(how, set, oldset);
 }
 
 // we need to wrap pthread_create so that we can safely implement a
 // stop-the-world quiescent period for the copy/mremap phase of
 // meshing
-int MESH_EXPORT pthread_create(pthread_t *thread, const pthread_attr_t *attr, mesh::PthreadFn startRoutine, void *arg) {
+int MESH_EXPORT pthread_create(pthread_t *thread, const pthread_attr_t *attr, mesh::PthreadFn startRoutine, void *arg) throw() {
   return mesh::runtime().createThread(thread, attr, startRoutine, arg);
 }
 

--- a/src/mini_heap.h
+++ b/src/mini_heap.h
@@ -113,7 +113,7 @@ private:
     }
   }
 
-  atomic_uint32_t _flags;
+  std::atomic<uint32_t> _flags;
 };
 
 class MiniHeap {

--- a/src/unit/concurrent_mesh_test.cc
+++ b/src/unit/concurrent_mesh_test.cc
@@ -31,7 +31,7 @@ static atomic<int> ShouldContinueTest;
 // we need to wrap pthread_create so that we can safely implement a
 // stop-the-world quiescent period for the copy/mremap phase of
 // meshing -- copied from libmesh.cc
-extern "C" int pthread_create(pthread_t *thread, const pthread_attr_t *attr, mesh::PthreadFn startRoutine, void *arg) {
+extern "C" int pthread_create(pthread_t *thread, const pthread_attr_t *attr, mesh::PthreadFn startRoutine, void *arg) throw() {
   return mesh::runtime().createThread(thread, attr, startRoutine, arg);
 }
 

--- a/src/unit/triple_mesh_test.cc
+++ b/src/unit/triple_mesh_test.cc
@@ -34,7 +34,7 @@ static atomic<int> ShouldContinueTest2;
 // we need to wrap pthread_create so that we can safely implement a
 // stop-the-world quiescent period for the copy/mremap phase of
 // meshing -- copied from libmesh.cc
-extern "C" int pthread_create(pthread_t *thread, const pthread_attr_t *attr, mesh::PthreadFn startRoutine, void *arg);
+extern "C" int pthread_create(pthread_t *thread, const pthread_attr_t *attr, mesh::PthreadFn startRoutine, void *arg) throw();
 
 static void writerThread1() {
   ShouldContinueTest1 = 1;


### PR DESCRIPTION
Some functions are marked constexpr when they are clearly not compile
time constant. Angers g++5.x and 8.x, clang seems to accept. Removed
constexpr attribute.

Overridden libc functions (sigaction, etc) differed from official
prototypes due to lack of a throw attribute, add missing attribute.

g++ 5.x does not implement atomic_uint32_t, replace with equivalent
std::atomic<uint32_t>.

With these changes build succeeds on Ubuntu 16 with g++5, Ubuntu 16
with clang 6, and Centos 7 with g++8.