### PR TITLE
improve multithreaded + slow-path performance

### DIFF
--- a/configure
+++ b/configure
@@ -111,14 +111,17 @@ c.append('libs', '-ldl')
 c.append('cxxflags', '-std=c++14 -I src')
 c.append('cxxflags', '$(CFLAGS)')
 
-# for development work, clang has much, much nicer error messages
-# c.prefer('cc', 'clang')
-# c.prefer('cxx', 'clang++')
+if c.clang:
+    # for development work, clang has much, much nicer error messages
+    c.prefer('cc', 'clang')
+    c.prefer('cxx', 'clang++')
 
-# c.prefer('ar', 'llvm-ar')
-# c.prefer('ranlib', 'llvm-ranlib')
+    c.prefer('ar', 'llvm-ar')
+    c.prefer('ranlib', 'llvm-ranlib')
 
 if not 'cc' in c.env or c.env['cc'] != 'clang':
     c.append('cflags', '-Wa,--noexecstack')
+else:
+    c.append('ldflags', '-fuse-ld=lld')
 
 c.generate()

--- a/src/common.h
+++ b/src/common.h
@@ -107,7 +107,7 @@ static constexpr size_t kAltStackSize = 16 * 1024UL;                       // 16
 #define SIGDUMP (SIGRTMIN + 8)
 
 // BinnedTracker
-static constexpr size_t kBinnedTrackerBinCount = 4;
+static constexpr size_t kBinnedTrackerBinCount = 1;
 static constexpr size_t kBinnedTrackerMaxEmpty = 128;
 
 static inline constexpr size_t PageCount(size_t sz) {

--- a/src/meshing.h
+++ b/src/meshing.h
@@ -16,8 +16,8 @@
 #include "internal.h"
 #include "mini_heap.h"
 
-#include "binned_tracker.h"
 #include "bitmap.h"
+#include "striped_tracker.h"
 
 namespace mesh {
 
@@ -46,7 +46,7 @@ inline bool bitmapsMeshable(const Bitmap::word_t *__restrict__ bitmap1, const Bi
 namespace method {
 
 // split miniheaps into two lists in a random order
-inline void halfSplit(MWC &prng, BinnedTracker &miniheaps, internal::vector<MiniHeap *> &left,
+inline void halfSplit(MWC &prng, StripedTracker &miniheaps, internal::vector<MiniHeap *> &left,
                       internal::vector<MiniHeap *> &right) noexcept {
   internal::vector<MiniHeap *> bucket = miniheaps.meshingCandidates(kOccupancyCutoff);
 
@@ -65,10 +65,11 @@ inline void halfSplit(MWC &prng, BinnedTracker &miniheaps, internal::vector<Mini
 }
 
 template <size_t t = 64>
-inline void shiftedSplitting(MWC &prng, BinnedTracker &miniheaps,
+inline void shiftedSplitting(MWC &prng, StripedTracker &miniheaps,
                              const function<void(std::pair<MiniHeap *, MiniHeap *> &&)> &meshFound) noexcept {
-  if (miniheaps.partialSize() == 0)
+  if (miniheaps.partialSize() == 0) {
     return;
+  }
 
   internal::vector<MiniHeap *> leftBucket{};   // mutable copy
   internal::vector<MiniHeap *> rightBucket{};  // mutable copy

--- a/src/thread_local_heap.h
+++ b/src/thread_local_heap.h
@@ -186,13 +186,15 @@ public:
     if (unlikely(ptr == nullptr))
       return;
 
-    auto mh = _global->miniheapFor(ptr);
+    size_t startEpoch{0};
+    auto mh = _global->miniheapForWithEpoch(ptr, startEpoch);
     if (likely(mh && mh->current() == _current && !mh->hasMeshed())) {
       ShuffleVector &shuffleVector = _shuffleVector[mh->sizeClass()];
       shuffleVector.free(mh, ptr);
       return;
     }
-    _global->freeFor(mh, ptr);
+
+    _global->freeFor(mh, ptr, startEpoch);
   }
 
   inline void ATTRIBUTE_ALWAYS_INLINE sizedFree(void *ptr, size_t sz) {

--- a/src/unit/binned_tracker_test.cc
+++ b/src/unit/binned_tracker_test.cc
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <cstdlib>
 
-#include "binned_tracker.h"
+#include "striped_tracker.h"
 
 #include "gtest/gtest.h"
 

--- a/src/unit/triple_mesh_test.cc
+++ b/src/unit/triple_mesh_test.cc
@@ -130,9 +130,9 @@ static void meshTestConcurrentWrite(bool invert1, bool invert2) {
     const auto f2 = reinterpret_cast<char *>(mh2->mallocAt(gheap.arenaBegin(), 2));
     const auto f3 = reinterpret_cast<char *>(mh3->mallocAt(gheap.arenaBegin(), 2));
 
-    mh1->unsetAttached();
-    mh2->unsetAttached();
-    mh3->unsetAttached();
+    gheap.releaseMiniheapLocked(mh1, mh1->sizeClass());
+    gheap.releaseMiniheapLocked(mh2, mh1->sizeClass());
+    gheap.releaseMiniheapLocked(mh3, mh1->sizeClass());
 
     gheap.free(f1);
     gheap.free(f2);
@@ -194,7 +194,7 @@ static void meshTestConcurrentWrite(bool invert1, bool invert2) {
   ASSERT_TRUE(mesh::bitmapsMeshable(bitmap1, bitmap3, len));
 
   {
-    const internal::vector<MiniHeap *> candidates = gheap.meshingCandidates(mh1->sizeClass());
+    const internal::vector<MiniHeap *> candidates = gheap.meshingCandidatesLocked(mh1->sizeClass());
     ASSERT_EQ(candidates.size(), 3ULL);
     ASSERT_TRUE(std::find(candidates.begin(), candidates.end(), mh1) != candidates.end());
     ASSERT_TRUE(std::find(candidates.begin(), candidates.end(), mh2) != candidates.end());
@@ -244,7 +244,7 @@ static void meshTestConcurrentWrite(bool invert1, bool invert2) {
   ASSERT_EQ(mh1->getOff(gheap.arenaBegin(), s3), 3);
 
   {
-    const internal::vector<MiniHeap *> candidates = gheap.meshingCandidates(mh1->sizeClass());
+    const internal::vector<MiniHeap *> candidates = gheap.meshingCandidatesLocked(mh1->sizeClass());
     ASSERT_EQ(candidates.size(), 1ULL);
     ASSERT_EQ(candidates[0], mh1);
   }

--- a/support/config.py
+++ b/support/config.py
@@ -79,6 +79,8 @@ class ConfigBuilder:
                             help='disable meshing')
         parser.add_argument('--suffix', action='store_true', default=False,
                             help='always suffix the mesh binary with randomization + meshing info')
+        parser.add_argument('--clang', action='store_true', default=False,
+                            help='build with clang')
 
         args = parser.parse_args()
 
@@ -86,6 +88,7 @@ class ConfigBuilder:
         self.gcov_build = args.gcov
         self.clangcov_build = args.clangcov
         self.optimize_build = args.optimize
+        self.clang = args.clang
 
         self.pkg_config = 'pkg-config'
 


### PR DESCRIPTION
In multi-threaded benchmarks like `larson`, multi-threaded performance is pretty bad.  This PR refactors things to avoid having to take locks in `GlobalHeap::freeFor` in significantly more cases.

The way we do this is by introducing an "epoch lock".  We read the value of this lock at the start of a free, unset a bit in a MiniHeap's bitmap in a CAS loop, and then re-read the value of the epoch lock.  If it is unchanged, we've successfully updated the MiniHeap's bitmap without taking a lock.  If the value not the same, it means a mesh has started or run concurrently with us (if the start epoch is odd, it also means a mesh is happening concurrently).  If this happens, we need to grab the global heap lock and synchronize.

This also fixes a bug where we were accumulating empty miniheaps in the BinnedTracker, but weren't considering them for re-use when re-filling a shuffle vector.

With two threads, our `larson` performance improves by 2.5x from:

```
Throughput =  3769033 operations per second.
```

to

```
XPS 08:35:46 (master) [bpowers@aika larson]$ perf record -g ./larson-mesh 5 8 128 10000 100 1 2
Throughput =  9671051 operations per second.
```