### PR TITLE
bug fixes and performance improvements

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -85,7 +85,7 @@ static constexpr size_t kMinArenaExpansion = 4096;  // 16 MB in pages
 // ensures we amortize the cost of going to the global heap enough
 static constexpr uint64_t kMinStringLen = 8;
 static constexpr size_t kMiniheapRefillGoalSize = 4 * 1024;
-static constexpr size_t kMaxMiniheapsPerShuffleVector = 8;
+static constexpr size_t kMaxMiniheapsPerShuffleVector = 16;
 
 // shuffle vector features
 static constexpr int16_t kMaxShuffleVectorLength = 256;  // sizeof(uint8_t) << 8

--- a/src/common.h
+++ b/src/common.h
@@ -85,7 +85,7 @@ static constexpr size_t kMinArenaExpansion = 4096;  // 16 MB in pages
 // ensures we amortize the cost of going to the global heap enough
 static constexpr uint64_t kMinStringLen = 8;
 static constexpr size_t kMiniheapRefillGoalSize = 4 * 1024;
-static constexpr size_t kMaxMiniheapsPerShuffleVector = 16;
+static constexpr size_t kMaxMiniheapsPerShuffleVector = 24;
 
 // shuffle vector features
 static constexpr int16_t kMaxShuffleVectorLength = 256;  // sizeof(uint8_t) << 8

--- a/src/fixed_array.h
+++ b/src/fixed_array.h
@@ -73,7 +73,7 @@ public:
   }
 
   void clear() {
-    memset(_objects, 0, Capacity * sizeof(T *));
+    // memset(_objects, 0, Capacity * sizeof(T *));
     _size = 0;
   }
 

--- a/src/shuffle_vector.h
+++ b/src/shuffle_vector.h
@@ -145,7 +145,7 @@ public:
 
   inline bool ATTRIBUTE_ALWAYS_INLINE localRefill() {
     uint32_t addedCapacity = 0;
-    auto miniheapCount = _attachedMiniheaps.size();
+    const auto miniheapCount = _attachedMiniheaps.size();
     for (uint32_t i = 0; i < miniheapCount && !isFull(); i++, _attachedOff++) {
       if (_attachedOff >= miniheapCount) {
         _attachedOff = 0;

--- a/src/striped_tracker.h
+++ b/src/striped_tracker.h
@@ -271,7 +271,7 @@ private:
     for (size_t i = 0; i < vec.size(); i++) {
       MiniHeap *mh = vec[i];
 
-      if (mh->isAttached() || mh->isFull()) {
+      if (mh->isAttached() || mh->isFull() || mh->isMeshed()) {
         continue;
       }
 


### PR DESCRIPTION
This PR tunes the number of MiniHeaps we pull down each time a thread's thread-local shuffle vector is empty. This reduces contention on the global heap's big lock, greatly improving performance.
