### PR TITLE
Fixes for CMake, Xcode build and additional targets for executables

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Run fork example
       run: cd cmake-cache && make run_fork-example
     - name: Run global-large-stress
-      run: cd cmake-cache && make global-large-stress
+      run: cd cmake-cache && make run_global-large-stress
     - name: Run local alloc
       run: cd cmake-cache && make run_local-alloc
     - name: Run thread
@@ -78,7 +78,7 @@ jobs:
     - name: Run fork example
       run: cd cmake-cache && make run_fork-example
     - name: Run global-large-stress
-      run: cd cmake-cache && make global-large-stress
+      run: cd cmake-cache && make run_global-large-stress
     - name: Run local alloc
       run: cd cmake-cache && make run_local-alloc
     - name: Run thread
@@ -113,7 +113,7 @@ jobs:
     - name: Run fork example
       run: cd cmake-cache && make run_fork-example
     - name: Run global-large-stress
-      run: cd cmake-cache && make global-large-stress
+      run: cd cmake-cache && make run_global-large-stress
     - name: Run local alloc
       run: cd cmake-cache && make run_local-alloc
     - name: Run thread
@@ -171,7 +171,7 @@ jobs:
   #  - name: Run fork example
   #    run: cd cmake-cache && ninja run_fork-example
   #  - name: Run global-large-stress
-  #    run: cd cmake-cache && ninja global-large-stress
+  #    run: cd cmake-cache && ninja run_global-large-stress
   #  - name: Run local alloc
   #    run: cd cmake-cache && ninja run_local-alloc
   #  - name: Run thread
@@ -206,7 +206,7 @@ jobs:
   #  - name: Run fork example
   #    run: cd cmake-cache && ninja run_fork-example
   #  - name: Run global-large-stress
-  #    run: cd cmake-cache && ninja global-large-stress
+  #    run: cd cmake-cache && ninja run_global-large-stress
   #  - name: Run local alloc
   #    run: cd cmake-cache && ninja run_local-alloc
   #  - name: Run thread

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,58 +30,23 @@ jobs:
       run: |
         cd cmake-cache
         make all
-    -  name: Run tests
-       run: |
-        cd cmake-cache
-        make coverage
-
-  Windows_MinGW:   
-  
-    runs-on: windows-latest
-  
-    steps:
-    - uses: actions/checkout@v1
-    - name: Install msys2/mingw64
-      #steps from https://github.com/msys2/MINGW-packages/blob/master/azure-pipelines.yml
-      run: |
-        git clone https://github.com/msys2/msys2-ci-base.git %CD:~0,2%\msys64
-        %CD:~0,2%\msys64\usr\bin\rm -rf %CD:~0,2%\msys64\.git
-        set PATH=%CD:~0,2%\msys64\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
-        %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Syyuu
-        set PATH=%CD:~0,2%\msys64\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
-        %CD:~0,2%\msys64\usr\bin\pacman --noconfirm --needed -S git base-devel
-        %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Scc
-    - name: Install required packages
-      run: |
-        set PATH=%CD:~0,2%\msys64\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
-        pacman -S --noconfirm mingw-w64-x86_64-binutils
-        pacman -S --noconfirm mingw-w64-x86_64-cmake
-        pacman -S --noconfirm mingw-w64-x86_64-gcc
-        pacman -S --noconfirm mingw-w64-x86_64-gcc-libs
-        pacman -S --noconfirm mingw-w64-x86_64-gcc-objc
-        pacman -S --noconfirm mingw-w64-x86_64-gdb
-        pacman -S --noconfirm mingw-w64-x86_64-ninja
-        pacman -S --noconfirm mingw-w64-x86_64-lcov
-        pacman -S --noconfirm mingw-w64-x86_64-winpthreads-git
-        pacman --noconfirm -Scc
-    - name: Configure CMake 
-      run: |
-        set PATH=%CD:~0,2%\msys64\mingw64\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
-        mkdir cmake-cache
-        cd cmake-cache
-        cmake -DGCOV=ON -G"Ninja" ..
-    - name: Build 
-      run: |
-        set PATH=%CD:~0,2%\msys64\mingw64\bin;%CD:~0,2%\msys64\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
-        cd cmake-cache
-        ninja
     - name: Run tests
       run: |
-        set PATH=%CD:~0,2%\msys64\mingw64\bin;%CD:~0,2%\msys64\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
-        cd cmake-cache
-        ninja coverage
+       cd cmake-cache
+       make coverage
+    - name: Run big alloc
+      run: cd cmake-cache && make run_big-alloc
+    - name: Run fork example
+      run: cd cmake-cache && make run_fork-example
+    - name: Run global-large-stress
+      run: cd cmake-cache && make global-large-stress
+    - name: Run local alloc
+      run: cd cmake-cache && make run_local-alloc
+    - name: Run thread
+      run: cd cmake-cache && make run_thread
+
  
-  Mac_OS_X:   
+  Mac_OS_X_GCC:   
   
     runs-on: macos-latest
   
@@ -103,12 +68,115 @@ jobs:
         export PATH="/usr/local/bin:$PATH"
         cd cmake-cache
         make all
-    -  name: Run tests
-       run: |
-         export PATH="/usr/local/bin:$PATH"
-         cd cmake-cache
-         make coverage
+    - name: Run tests
+      run: |
+        export PATH="/usr/local/bin:$PATH"
+        cd cmake-cache
+        make coverage
+    - name: Run big alloc
+      run: cd cmake-cache && make run_big-alloc
+    - name: Run fork example
+      run: cd cmake-cache && make run_fork-example
+    - name: Run global-large-stress
+      run: cd cmake-cache && make global-large-stress
+    - name: Run local alloc
+      run: cd cmake-cache && make run_local-alloc
+    - name: Run thread
+      run: cd cmake-cache && make run_thread
+
+
+ 
+  Mac_OS_X_Xcode:   
   
+    runs-on: macos-latest
+  
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install required packages
+      run: |
+        brew install cmake lcov make
+    - name: Configure CMake in debug mode
+      run: |
+        mkdir cmake-cache
+        cd cmake-cache
+        cmake -DGCOV=ON ..
+    - name: Build 
+      run: |
+        cd cmake-cache
+        make all
+    - name: Run tests
+      run: |
+        cd cmake-cache
+        make coverage
+    - name: Run big alloc
+      run: cd cmake-cache && make run_big-alloc
+    - name: Run fork example
+      run: cd cmake-cache && make run_fork-example
+    - name: Run global-large-stress
+      run: cd cmake-cache && make global-large-stress
+    - name: Run local alloc
+      run: cd cmake-cache && make run_local-alloc
+    - name: Run thread
+      run: cd cmake-cache && make run_thread
+  
+
+
+  #Windows_MinGW:   
+  #
+  #  runs-on: windows-latest
+  #
+  #  steps:
+  #  - uses: actions/checkout@v1
+  #  - name: Install msys2/mingw64
+  #    #steps from https://github.com/msys2/MINGW-packages/blob/master/azure-pipelines.yml
+  #    run: |
+  #      git clone https://github.com/msys2/msys2-ci-base.git %CD:~0,2%\msys64
+  #      %CD:~0,2%\msys64\usr\bin\rm -rf %CD:~0,2%\msys64\.git
+  #      set PATH=%CD:~0,2%\msys64\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
+  #      %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Syyuu
+  #      set PATH=%CD:~0,2%\msys64\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
+  #      %CD:~0,2%\msys64\usr\bin\pacman --noconfirm --needed -S git base-devel
+  #      %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Scc
+  #  - name: Install required packages
+  #    run: |
+  #      set PATH=%CD:~0,2%\msys64\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
+  #      pacman -S --noconfirm mingw-w64-x86_64-binutils
+  #      pacman -S --noconfirm mingw-w64-x86_64-cmake
+  #      pacman -S --noconfirm mingw-w64-x86_64-gcc
+  #      pacman -S --noconfirm mingw-w64-x86_64-gcc-libs
+  #      pacman -S --noconfirm mingw-w64-x86_64-gcc-objc
+  #      pacman -S --noconfirm mingw-w64-x86_64-gdb
+  #      pacman -S --noconfirm mingw-w64-x86_64-ninja
+  #      pacman -S --noconfirm mingw-w64-x86_64-lcov
+  #      pacman -S --noconfirm mingw-w64-x86_64-winpthreads-git
+  #      pacman --noconfirm -Scc
+  #  - name: Configure CMake
+  #    run: |
+  #      set PATH=%CD:~0,2%\msys64\mingw64\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
+  #      mkdir cmake-cache
+  #      cd cmake-cache
+  #      cmake -DGCOV=ON -G"Ninja" ..
+  #  - name: Build
+  #    run: |
+  #      set PATH=%CD:~0,2%\msys64\mingw64\bin;%CD:~0,2%\msys64\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
+  #      cd cmake-cache
+  #      ninja
+  #  - name: Run tests
+  #    run: |
+  #      set PATH=%CD:~0,2%\msys64\mingw64\bin;%CD:~0,2%\msys64\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
+  #      cd cmake-cache
+  #      ninja coverage
+  #  - name: Run big alloc
+  #    run: cd cmake-cache && ninja run_big-alloc
+  #  - name: Run fork example
+  #    run: cd cmake-cache && ninja run_fork-example
+  #  - name: Run global-large-stress
+  #    run: cd cmake-cache && ninja global-large-stress
+  #  - name: Run local alloc
+  #    run: cd cmake-cache && ninja run_local-alloc
+  #  - name: Run thread
+  #    run: cd cmake-cache && ninja run_thread
+
   #Windows_Visual_Studio:   #not working
   #
   #  runs-on: windows-latest
@@ -133,5 +201,14 @@ jobs:
   #    run: |
   #      cd cmake-cache
   #      ninja coverage
-
+  #  - name: Run big alloc
+  #    run: cd cmake-cache && ninja run_big-alloc
+  #  - name: Run fork example
+  #    run: cd cmake-cache && ninja run_fork-example
+  #  - name: Run global-large-stress
+  #    run: cd cmake-cache && ninja global-large-stress
+  #  - name: Run local alloc
+  #    run: cd cmake-cache && ninja run_local-alloc
+  #  - name: Run thread
+  #    run: cd cmake-cache && ninja run_thread
 

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,13 @@ __pycache__
 /.idea
 /.clwb
 /cmake-build*
+
+cmake-cache/
+
+cmake-build-debug/
+
+cmake-build-release/
+
+cmake-build-relwithdebinfo/
+
+cmake-build-minsizerel/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ add_definitions(-fPIC
 # c.append('cflags', '-Wno-c99-extensions
 
 #Language specific definitions
-#Quotes and slashes to scape spaces.
+#Quotes for string and backslashes to scape newline.
 set(custom_c_flags
      "-Werror=implicit-function-declaration\
       -Werror=implicit-int\

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,11 @@ project(Mesh CXX C)
 SET(CMAKE_BUILD_TYPE "" CACHE STRING "Just making sure the default CMAKE_BUILD_TYPE configurations won't interfere" FORCE)
 
 #Set output folders 
-set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/build)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_HEADER_OUTPUT_DIRECTORY  ${CMAKE_BINARY_DIR}/include)
+set(CMAKE_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/build)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_OUTPUT_DIRECTORY}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_OUTPUT_DIRECTORY}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_OUTPUT_DIRECTORY}/lib)
+set(CMAKE_HEADER_OUTPUT_DIRECTORY  ${CMAKE_OUTPUT_DIRECTORY}/include)
 
 
 #Fetch submodules
@@ -176,7 +176,7 @@ add_definitions(-fPIC
 # c.append('cflags', '-Wno-gnu-statement-expression
 # c.append('cflags', '-Wno-c99-extensions
 
-if (NOT APPLE AND NOT WIN32)
+if (NOT APPLE AND NOT WIN)
     add_definitions(
             -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_XOPEN_SOURCE=700
             -Wundef
@@ -196,6 +196,7 @@ if (NOT APPLE AND NOT WIN32)
             -lrt
         )
 endif()
+
 
 add_link_options(-lm -lpthread -pthread -ldl)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,25 +156,35 @@ add_definitions(-fPIC
                 -fno-omit-frame-pointer
                 -ffunction-sections
                 -fdata-sections
-                -Werror=implicit-function-declaration
-                -Werror=implicit-int
-                -Werror=pointer-sign
                 -Werror=pointer-arith
                 -Wall -Wextra -pedantic
-                -Wno-unused-parameter
-                -Wno-unused-variable
-                -Woverloaded-virtual
                 -Werror=return-type
                 -Wtype-limits
                 -Wempty-body
-                -Wno-ctor-dtor-privacy
-                -Winvalid-offsetof
                 -Wvariadic-macros
                 -Wcast-align
                 -fvisibility=hidden
         )
 # c.append('cflags', '-Wno-gnu-statement-expression
 # c.append('cflags', '-Wno-c99-extensions
+
+#Language specific definitions
+#Quotes and slashes to scape spaces.
+set(custom_c_flags
+     "-Werror=implicit-function-declaration\
+      -Werror=implicit-int\
+      -Werror=pointer-sign\
+     ")
+set(custom_cxx_flags
+    "-Wno-unused-parameter\
+     -Wno-unused-variable\
+     -Woverloaded-virtual\
+     -Wno-ctor-dtor-privacy\
+     -Winvalid-offsetof\
+    ")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${custom_c_flags}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${custom_cxx_flags}")
 
 if (NOT APPLE AND NOT WIN)
     add_definitions(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ add_definitions(-fPIC
 # c.append('cflags', '-Wno-c99-extensions
 
 #Language specific definitions
-#Quotes for string and backslashes to scape newline.
+#Quotes for string and backslashes to escape newline.
 set(custom_c_flags
      "-Werror=implicit-function-declaration\
       -Werror=implicit-int\

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,16 +42,49 @@ set(google_src
         vendor/googletest/googletest/src/gtest_main.cc
         )
 
-#Add definition required by the Google tests
+#Add definition required by the Google tests (to make it stop complaining)
 if (WIN)
-    add_definitions(-DGTEST_OS_WINDOWS)
+    set(win_def -DGTEST_OS_MAC=0
+                -DGTEST_OS_LINUX=0
+                -DGTEST_OS_WINDOWS
+            )
 elseif(APPLE)
-    add_definitions(-DGTEST_OS_MAC)
+    set(apple_def -DGTEST_OS_MAC
+                  -DGTEST_OS_LINUX=0
+                  -DGTEST_OS_WINDOWS=0
+            )
 elseif(UNIX AND NOT APPLE)
-    add_definitions(-DGTEST_OS_LINUX)
+    set(linux_def -DGTEST_OS_MAC=0
+                  -DGTEST_OS_LINUX
+                  -DGTEST_OS_WINDOWS=0
+            )
 else()
     message(FATAL_ERROR Unsupported platform)
 endif()
+set(google_tests_definitions
+        -DGTEST_FOR_GOOGLE_=0
+        -DGTEST_HAS_ABSL=0
+        -DGTEST_IS_THREADSAFE=1
+        -DGTEST_OS_AIX=0
+        -DGTEST_OS_FUCHSIA=0
+        -DGTEST_OS_IOS=0
+        ${linux_def}
+        -DGTEST_OS_LINUX_ANDROID=0
+        ${apple_def}
+        -DGTEST_OS_NACL=0
+        -DGTEST_OS_OS2=0
+        -DGTEST_OS_QNX=0
+        -DGTEST_OS_SYMBIAN=0
+        -DGTEST_OS_USES_PCRE=0
+        ${win_def}
+        -DGTEST_OS_WINDOWS_MOBILE=0
+        -DGTEST_OS_WINDOWS_PHONE=0
+        -DGTEST_OS_WINDOWS_RT=0
+        -DGTEST_OS_ZOS=0
+        -DGTEST_USES_PCRE=0
+        -DGTEST_USES_SIMPLE_RE=0
+)
+
 
 #Create a set of source files for the unit tests
 set(unit_src
@@ -74,7 +107,7 @@ target_include_directories(unit.test SYSTEM PRIVATE vendor/googletest/googletest
 target_include_directories(unit.test PRIVATE vendor/googletest/googletest)
 
 #Set specific compiler flags for the unit tests
-target_compile_definitions(unit.test PRIVATE -DGTEST_HAS_PTHREAD=1)
+target_compile_definitions(unit.test PRIVATE -DGTEST_HAS_PTHREAD=1 ${google_tests_definitions})
 target_compile_options(unit.test PRIVATE -Wno-unused-const-variable)
 
 #Create targets for each test

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,7 +43,7 @@ set(google_src
         )
 
 #Add definition required by the Google tests
-if (WIN32)
+if (WIN)
     add_definitions(-DGTEST_OS_WINDOWS)
 elseif(APPLE)
     add_definitions(-DGTEST_OS_MAC)
@@ -85,6 +85,12 @@ function (add_mesh_test testname testfilename libraries_to_link)
         target_link_libraries(${testname} "${libraries_to_link}")
     endif()
     target_compile_options(${testname} PRIVATE -pipe -fno-builtin-malloc -fno-omit-frame-pointer)
+
+    #Include target to run the executable
+    add_custom_target(run_${testname}
+            COMMAND ${testname}
+            WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+            DEPENDS ${testname})
 endfunction(add_mesh_test)
 
 set(test_filenames
@@ -125,7 +131,7 @@ set(hoard_src
         vendor/Hoard/src/source/libhoard.cpp
         vendor/Hoard/src/source/uselibhoard.cpp
         )
-if(WIN32)
+if(WIN)
     list(APPEND hoard_src vendor/Hoard/src/source/wintls.cpp)
 elseif(APPLE)
     list(APPEND hoard_src vendor/Hoard/src/source/mactls.cpp)
@@ -148,8 +154,8 @@ if(${GCOV})
     target_compile_options(unit.test PRIVATE -fprofile-arcs -ftest-coverage)
     target_link_options(unit.test PRIVATE -fprofile-arcs -ftest-coverage)
     add_custom_target(coverage
-            COMMAND cd ${CMAKE_SOURCE_DIR}/cmake-cache/src/CMakeFiles/unit.test.dir/ && ${CMAKE_SOURCE_DIR}/build/bin/unit.test
-            COMMAND lcov -o app.info -c --directory ${CMAKE_SOURCE_DIR}/cmake-cache/src/CMakeFiles/unit.test.dir/
+            COMMAND cd ${CMAKE_BINARY_DIR}/src/CMakeFiles/unit.test.dir/ && ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unit.test
+            COMMAND lcov -o app.info -c --directory ${CMAKE_BINARY_DIR}/src/CMakeFiles/unit.test.dir/
             COMMAND genhtml app.info
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/coverage/
             DEPENDS unit.test)

--- a/src/common.h
+++ b/src/common.h
@@ -43,6 +43,7 @@
 #endif
 
 namespace mesh {
+    
 static constexpr bool kMeshingEnabled = MESHING_ENABLED == 1;
 
 #if defined(_WIN32)
@@ -100,8 +101,11 @@ static constexpr std::chrono::milliseconds kMeshPeriodMs{100};  // 100 ms
 
 // controls aspects of miniheaps
 static constexpr size_t kMaxMeshes = 256;  // 1 per bit
-
+#ifdef __APPLE__
+static constexpr size_t kArenaSize = 32ULL * 1024ULL * 1024ULL * 1024ULL;  // 16 GB
+#else
 static constexpr size_t kArenaSize = 64ULL * 1024ULL * 1024ULL * 1024ULL;  // 64 GB
+#endif
 static constexpr size_t kAltStackSize = 16 * 1024UL;                       // 16k sigaltstacks
 #define SIGQUIESCE (SIGRTMIN + 7)
 #define SIGDUMP (SIGRTMIN + 8)

--- a/src/meshable_arena.cc
+++ b/src/meshable_arena.cc
@@ -471,6 +471,7 @@ void MeshableArena::freePhys(void *ptr, size_t sz) {
     int result = fallocate(_fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, off, sz);
     d_assert(result == 0);
 #else
+    #warning macOS version of fallocate goes here
     fstore_t store = {F_ALLOCATECONTIG, F_PEOFPOSMODE, 0,(long long) sz, 0};
     int result = fcntl(_fd, F_PREALLOCATE, &store);
     if (result == -1) {


### PR DESCRIPTION
Fixes for CMake cache folder, build and warnings: now the build will be much less verbose without complains of c++ flags on c programs and c flags on c++ programs. I fixed a mistake on the cache folder (CMAKE_BINARY_DIR is the build tree root and changing it was a bad idea). Made a few changes to be able to build on Mac OS.

Added a Xcode workflow where at least the unit tests worked with fnctl replacing fallocate (neither fallocate nor posix_fallocate are present on Mac OS). 

Also included additional targets to run the other executables after the unit tests.