### PR TITLE
build: installation support for CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,8 @@ set_property(CACHE RANDOMIZATION PROPERTY STRINGS "0;1;2")
 option(DISABLE_MESHING "Disable meshing" OFF)
 option(SUFFIX "Always suffix the mesh library with randomization + meshing info" OFF)
 option(CLANG "Build with clang" OFF)
+option(INSTALL_MESH "Install mesh to the system" OFF)
+option(SYS_WIDE_INSTALL "Install mesh as a system-wide library" OFF)
 
 
 
@@ -228,6 +230,75 @@ file(MAKE_DIRECTORY ${PROJECT_SOURCE_DIR}/coverage)
 #Go to subdirectory to build libraries
 add_subdirectory(src)
 
+#Installation procedures
+if(INSTALL_MESH)
+    #Check OS and target installation directories
+    if(WIN32)
+        set(system_wide_installation_dir C:\\Program Files\\mesh)
+        set(user_wide_installation_dir C:\\User\\$ENV{USERNAME}\\AppData\\Local\\mesh)
+        set(user $ENV{USERNAME})
+        add_custom_target(delete_local_installation_dir
+                COMMAND ${CMAKE_COMMAND} -E remove_directory ${user_wide_installation_dir})
+    elseif(APPLE)
+        set(system_wide_installation_dir /usr/local)
+        set(user_wide_installation_dir /Users/$ENV{USER}/Library/mesh)
+        set(user $ENV{USER})
+        add_custom_target(delete_local_installation_dir
+                COMMAND ${CMAKE_COMMAND} -E remove_directory ${user_wide_installation_dir})
+    else()
+        #Linux
+        set(system_wide_installation_dir /usr/local)
+        set(user_wide_installation_dir /home/$ENV{USERNAME}/.local)
+        set(user $ENV{USERNAME})
+        add_custom_target(delete_local_installation_dir)
+    endif()
 
+    #This check prevents that running installation as sudo changes the username
+    if(NOT ENV{mesh_install_dir})
+        if(SYS_WIDE_INSTALL)
+            set(ENV{mesh_install_dir} ${system_wide_installation_dir})
+            set(ENV{mesh_syswide} ON)
+        else()
+            set(ENV{mesh_install_dir} ${user_wide_installation_dir})
+            set(ENV{mesh_syswide} OFF)
+        endif()
+        set(ENV{mesh_user} ${user})
+    endif()
 
-#Todo: deal with installation
+    #Create target for copying library and header dir
+    add_custom_target(install_mesh
+            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:mesh> $ENV{mesh_install_dir}/lib/$<TARGET_FILE_NAME:mesh>
+            COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/src/plasma/mesh.h $ENV{mesh_install_dir}/include/plasma/mesh.h
+            )
+    #Create target for deleting library and header dir
+    add_custom_target(uninstall_mesh
+            COMMAND ${CMAKE_COMMAND} -E remove -f $ENV{mesh_install_dir}/lib/$<TARGET_FILE_NAME:mesh>
+            COMMAND ${CMAKE_COMMAND} -E remove -f $ENV{mesh_install_dir}/include/plasma/mesh.h
+            COMMAND ${CMAKE_COMMAND} -E remove_directory $ENV{mesh_install_dir}/include/plasma
+            )
+
+    #Export or remove library paths (you will need to run with sudo/elevated privileges if doing a system wide installation)
+    #I didn't add a DEPENDS clause on purpose, or the mesh and install_mesh targets would run as root
+    add_custom_target(export_mesh
+            COMMAND ${CMAKE_COMMAND} -DINSTALLATION_DIR="$ENV{mesh_install_dir}" -DUSER="$ENV{mesh_user}" -DSYSWIDE="$ENV{mesh_syswide}" -P ${CMAKE_SOURCE_DIR}/support/export_mesh.cmake
+            )
+    add_custom_target(remove_export_mesh
+            COMMAND ${CMAKE_COMMAND} -DINSTALLATION_DIR="$ENV{mesh_install_dir}" -DUSER="$ENV{mesh_user}" -DSYSWIDE="$ENV{mesh_syswide}" -P ${CMAKE_SOURCE_DIR}/support/remove_export_mesh.cmake
+            )
+
+    #Additional glue targets that trigger both install&export or uninstall&remove export
+    add_custom_target(install_and_export
+            DEPENDS install_mesh export_mesh
+            )
+
+    if(SYS_WIDE_INSTALL)
+        add_custom_target(uninstall_and_remove_export
+                DEPENDS uninstall_mesh remove_export_mesh
+                )
+    else()
+        add_custom_target(uninstall_and_remove_export
+                DEPENDS uninstall_mesh remove_export_mesh delete_local_installation_dir
+                )
+    endif()
+
+endif()

--- a/support/export_mesh.cmake
+++ b/support/export_mesh.cmake
@@ -1,0 +1,28 @@
+#Edit configuration files to export mesh folder and auxiliary variables
+
+set(LINUX_BASH_FILE /home/${USER}/.bashrc)
+set(MAC_BASH_FILE /Users/${USER}/.bash_profile)
+
+if(SYSWIDE)
+    #Install to system/public folders (exports the path to the library and refresh cache on Linux). Mac is weird, the library was completely ignored.
+    if(WIN32)
+        execute_process(COMMAND setx /M LIBMESH_PATH "${INSTALLATION_DIR}\\lib\\")
+    elseif(APPLE)
+        file(APPEND ${MAC_BASH_FILE} "export DYLD_FALLBACK_LIBRARY_PATH=\"${INSTALLATION_DIR}/lib/\"\nexport LIBMESH_PATH=\"${INSTALLATION_DIR}/lib/\"\n")
+    else()
+        #Linux
+        file(WRITE "/etc/ld.so.conf.d/mesh.conf" "${INSTALLATION_DIR}/lib") #write path to libmesh
+        execute_process(COMMAND ldconfig) # renew shared lib cache
+        file(APPEND ${LINUX_BASH_FILE} "export LIBMESH_PATH=\"${INSTALLATION_DIR}/lib/\"\n") #not really necessary, but just to make things consistent
+    endif()
+else()
+    #Install to user profile (just exports a variable containing the path to the library)
+    if(WIN32)
+        execute_process(COMMAND setx LIBMESH_PATH "${INSTALLATION_DIR}\\lib\\")
+    elseif(APPLE)
+        file(APPEND ${MAC_BASH_FILE} "export LIBMESH_PATH=\"${INSTALLATION_DIR}/lib/\"\n")
+    else()
+        #Linux
+        file(APPEND ${LINUX_BASH_FILE} "export LIBMESH_PATH=\"${INSTALLATION_DIR}/lib/\"\n")
+    endif()
+endif()

--- a/support/remove_export_mesh.cmake
+++ b/support/remove_export_mesh.cmake
@@ -1,0 +1,48 @@
+#Edit configuration files to remove mesh exported configs and varaibles
+
+function(get_rid_of_path bash_config_contents path_to_get_rid bash_contents_updated)
+    #Remove libmesh path export
+    string(REPLACE "export LIBMESH_PATH=\"${path_to_get_rid}\"\n" " " bash_config_content_lines "${bash_config_contents}")
+    #Remove DYLD_FALLBACK export
+    string(REPLACE "export DYLD_FALLBACK_LIBRARY_PATH=\"${path_to_get_rid}\"\n" "" bash_config_contents "${bash_config_content_lines}")
+    #Save results to the variable from the parent scope
+    set(bash_contents_updated "${bash_config_contents}" PARENT_SCOPE)
+endfunction(get_rid_of_path)
+
+
+set(LINUX_BASH_FILE /home/${USER}/.bashrc)
+set(MAC_BASH_FILE /Users/${USER}/.bash_profile)
+
+if(SYSWIDE)
+    #Install to system/public folders (exports the path to the library and refresh cache on Linux). Mac is weird, the library was completely ignored.
+    if(WIN32)
+        #Remove exported variables
+        execute_process(COMMAND setx /M LIBMESH_PATH=)
+    elseif(APPLE)
+    else()
+        #Linux
+        file(REMOVE "/etc/ld.so.conf.d/mesh.conf") #write path to libmesh
+        execute_process(COMMAND ldconfig) # renew shared lib cache
+    endif()
+endif()
+
+#Install to user profile (just exports a variable containing the path to the library)
+if(WIN32)
+    #Remove exported variable
+    execute_process(COMMAND setx LIBMESH_PATH=)
+elseif(APPLE)
+    #Remove exported variable
+    file(COPY ${MAC_BASH_FILE} DESTINATION ${MAC_BASH_FILE}.bak) #backup before doing anything
+    file(READ ${MAC_BASH_FILE} bash_contents)
+    set(bash_contents_updated)
+    get_rid_of_path("${bash_contents}" "${INSTALLATION_DIR}/lib/" bash_contents_updated)
+    file(WRITE ${MAC_BASH_FILE} "${bash_contents_updated}")
+else()
+    #Linux
+    #Remove exported variable
+    file(COPY ${LINUX_BASH_FILE} DESTINATION ${LINUX_BASH_FILE}.bak) #backup before doing anything
+    file(READ ${LINUX_BASH_FILE} bash_contents)
+    set(bash_contents_updated)
+    get_rid_of_path("${bash_contents}" "${INSTALLATION_DIR}/lib/" bash_contents_updated)
+    file(WRITE ${LINUX_BASH_FILE} "${bash_contents_updated}")
+endif()

--- a/support/remove_export_mesh.cmake
+++ b/support/remove_export_mesh.cmake
@@ -2,7 +2,7 @@
 
 function(get_rid_of_path bash_config_contents path_to_get_rid bash_contents_updated)
     #Remove libmesh path export
-    string(REPLACE "export LIBMESH_PATH=\"${path_to_get_rid}\"\n" " " bash_config_content_lines "${bash_config_contents}")
+    string(REPLACE "export LIBMESH_PATH=\"${path_to_get_rid}\"\n" "" bash_config_content_lines "${bash_config_contents}")
     #Remove DYLD_FALLBACK export
     string(REPLACE "export DYLD_FALLBACK_LIBRARY_PATH=\"${path_to_get_rid}\"\n" "" bash_config_contents "${bash_config_content_lines}")
     #Save results to the variable from the parent scope


### PR DESCRIPTION
It currently requires the user to delete the entire cmake cache to swap between user-wide and system-wide. Also, the user shouldn't run cmake with sudo (there's no good reason to do it anyways), or the wrong username will be used.

After running cmake with -DINSTALL_MESH=ON, a few targets will appear: install_mesh (builds and copies to the installation directory). The export_mesh (creates an environment variable LIBMESH_PATH with the installation directory/lib and some other OS specific procedures if -DSYS_WIDE_INSTALL=ON). The install_and_export target runs both of them. They have their conterparts to remove the library and undo the export phase.

Still requires testing on Windows, but the installation procedure should work just fine.