### PR TITLE
Changed a comparison with an integer to use ==

### DIFF
--- a/support/config.py
+++ b/support/config.py
@@ -132,7 +132,7 @@ class ConfigBuilder:
 
         env = self.env
         path = run_cmd('which %s' % (program))
-        if len(path) is 0:
+        if len(path) == 0:
             stderr.write('required program "%s" not found.\n' % program)
             exit(1)
 


### PR DESCRIPTION
Correct a syntax error on Python 3.8
```
/mesh/support/config.py:135: SyntaxWarning: "is" with a literal. Did you
mean "=="?
  if len(path) is 0:
```