### PR TITLE
combine the madvise

### DIFF
--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -140,8 +140,7 @@ public:
   }
 
   inline uint32_t ATTRIBUTE_ALWAYS_INLINE inUseCount() const {
-    return popcount64(_bits[0]) + popcount64(_bits[1]) + popcount64(_bits[2]) +
-           popcount64(_bits[3]);
+    return popcount64(_bits[0]) + popcount64(_bits[1]) + popcount64(_bits[2]) + popcount64(_bits[3]);
   }
 
 protected:

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -140,8 +140,8 @@ public:
   }
 
   inline uint32_t ATTRIBUTE_ALWAYS_INLINE inUseCount() const {
-    return __builtin_popcountl(_bits[0]) + __builtin_popcountl(_bits[1]) + __builtin_popcountl(_bits[2]) +
-           __builtin_popcountl(_bits[3]);
+    return popcount64(_bits[0]) + popcount64(_bits[1]) + popcount64(_bits[2]) +
+           popcount64(_bits[3]);
   }
 
 protected:
@@ -232,7 +232,7 @@ public:
     const auto wordCount = representationSize(_bitCount) / sizeof(size_t);
     uint32_t count = 0;
     for (size_t i = 0; i < wordCount; i++) {
-      count += __builtin_popcountl(_bits[i]);
+      count += popcount64(_bits[i]);
     }
     return count;
   }
@@ -318,12 +318,12 @@ public:
     constexpr auto wordCount = representationSize(maxBits) / sizeof(size_t);
     uint32_t count = 0;
     // for (size_t i = 0; i < wordCount; i++) {
-    //   count += __builtin_popcountl(_bits[i]);
+    //   count += popcount64(_bits[i]);
     // }
-    count += __builtin_popcountl(_bits[0]);
-    count += __builtin_popcountl(_bits[1]);
-    count += __builtin_popcountl(_bits[2]);
-    count += __builtin_popcountl(_bits[3]);
+    count += popcount64(_bits[0]);
+    count += popcount64(_bits[1]);
+    count += popcount64(_bits[2]);
+    count += popcount64(_bits[3]);
     return count;
   }
 

--- a/src/cheap_heap.h
+++ b/src/cheap_heap.h
@@ -53,12 +53,12 @@ public:
 
     if (kAdviseDump) {
       // only call madvise at a new page
-      if((uint64_t)ptr % kPageSize == 0) {
+      if ((uint64_t)ptr % kPageSize == 0) {
         madvise(ptr, kPageSize, MADV_DODUMP);
       }
 
-      void* freelistPage = _freelist + off * sizeof(void*);
-      if((uint64_t)freelistPage % kPageSize == 0) {
+      void *freelistPage = _freelist + off * sizeof(void *);
+      if ((uint64_t)freelistPage % kPageSize == 0) {
         madvise(freelistPage, kPageSize, MADV_DODUMP);
       }
     }
@@ -142,15 +142,16 @@ public:
 
     if (kAdviseDump) {
       // only call madvise at a new page
-      if((uint64_t)ptr % kPageSize == 0) {
+      if ((uint64_t)ptr % kPageSize == 0) {
         madvise(ptr, kPageSize, MADV_DODUMP);
         // debug("ptr -> madvise(%p, kPageSize, MADV_DODUMP) %d\n", ptr, (uint64_t)ptr % kPageSize);
       }
 
-      void* freelistPage = _freelist + off * sizeof(void*);
-      if((uint64_t)freelistPage % kPageSize == 0) {
+      void *freelistPage = _freelist + off * sizeof(void *);
+      if ((uint64_t)freelistPage % kPageSize == 0) {
         madvise(freelistPage, kPageSize, MADV_DODUMP);
-        // debug("freelistPage -> madvise(%p, kPageSize, MADV_DODUMP) %d\n", freelistPage, (uint64_t)freelistPage % kPageSize);
+        // debug("freelistPage -> madvise(%p, kPageSize, MADV_DODUMP) %d\n", freelistPage, (uint64_t)freelistPage %
+        // kPageSize);
       }
     }
 

--- a/src/cheap_heap.h
+++ b/src/cheap_heap.h
@@ -121,6 +121,19 @@ public:
 
     const auto off = _arenaOff++;
     const auto ptr = ptrFromOffset(off);
+
+    if (kAdviseDump) {
+      // only call madvise at a new page
+      if((uint64_t)ptr % kPageSize == 0) {
+        madvise(ptr, kPageSize, MADV_DODUMP);
+      }
+
+      void* freelistPage = _freelist + off * sizeof(void*);
+      if((uint64_t)freelistPage % kPageSize == 0) {
+        madvise(freelistPage, kPageSize, MADV_DODUMP);
+      }
+    }
+
     hard_assert(ptr < arenaEnd());
     return ptr;
   }

--- a/src/common.h
+++ b/src/common.h
@@ -165,32 +165,26 @@ using std::unique_lock;
 #define likely(x) __builtin_expect(!!(x), 1)
 #define unlikely(x) __builtin_expect(!!(x), 0)
 
-
 #ifdef __GNUC__
-  #define GNUC_PREREQ(x, y) \
-      (__GNUC__ > x || (__GNUC__ == x && __GNUC_MINOR__ >= y))
+#define GNUC_PREREQ(x, y) (__GNUC__ > x || (__GNUC__ == x && __GNUC_MINOR__ >= y))
 #else
-  #define GNUC_PREREQ(x, y) 0
+#define GNUC_PREREQ(x, y) 0
 #endif
 
 #ifdef __clang__
-  #define CLANG_PREREQ(x, y) \
-      (__clang_major__ > x || (__clang_major__ == x && __clang_minor__ >= y))
+#define CLANG_PREREQ(x, y) (__clang_major__ > x || (__clang_major__ == x && __clang_minor__ >= y))
 #else
-  #define CLANG_PREREQ(x, y) 0
+#define CLANG_PREREQ(x, y) 0
 #endif
 
-#if GNUC_PREREQ(4, 2) || \
-    CLANG_PREREQ(3, 0)
-  #define HAVE_ASM_POPCNT
+#if GNUC_PREREQ(4, 2) || CLANG_PREREQ(3, 0)
+#define HAVE_ASM_POPCNT
 #endif
 
-#if defined(HAVE_ASM_POPCNT) && \
-    defined(__x86_64__)
+#if defined(HAVE_ASM_POPCNT) && defined(__x86_64__)
 
-static inline uint64_t popcnt64(uint64_t x)
-{
-  __asm__ ("popcnt %1, %0" : "=r" (x) : "0" (x));
+static inline uint64_t popcnt64(uint64_t x) {
+  __asm__("popcnt %1, %0" : "=r"(x) : "0"(x));
   return x;
 }
 #define popcount64(x) popcnt64(x)
@@ -240,20 +234,18 @@ static inline uint64_t popcnt64(uint64_t x)
   ((likely(expr)) ? static_cast<void>(0) \
                   : mesh::internal::__mesh_assert_fail(#expr, __FILE__, __PRETTY_FUNCTION__, __LINE__, ""))
 
-
-ATTRIBUTE_ALWAYS_INLINE inline void cpupause()
-{
+ATTRIBUTE_ALWAYS_INLINE inline void cpupause() {
 #if defined(_MSC_VER)
 #if defined(_M_AMD64) || defined(_M_IX86)
-    _mm_pause();
+  _mm_pause();
 #elif defined(_M_ARM64) || defined(_M_ARM)
-    __yield();
+  __yield();
 #endif
 #elif defined(__GNUC__)
 #if defined(__i386__) || defined(__x86_64__)
-    __asm__ __volatile__("pause;" : : : "memory");
+  __asm__ __volatile__("pause;" : : : "memory");
 #elif (defined(__ARM_ARCH) && __ARM_ARCH >= 8) || defined(__ARM_ARCH_8A__) || defined(__aarch64__)
-    __asm__ __volatile__("yield;" : : : "memory");
+  __asm__ __volatile__("yield;" : : : "memory");
 #endif
 #endif
 }

--- a/src/common.h
+++ b/src/common.h
@@ -240,6 +240,24 @@ static inline uint64_t popcnt64(uint64_t x)
   ((likely(expr)) ? static_cast<void>(0) \
                   : mesh::internal::__mesh_assert_fail(#expr, __FILE__, __PRETTY_FUNCTION__, __LINE__, ""))
 
+
+ATTRIBUTE_ALWAYS_INLINE inline void cpupause()
+{
+#if defined(_MSC_VER)
+#if defined(_M_AMD64) || defined(_M_IX86)
+    _mm_pause();
+#elif defined(_M_ARM64) || defined(_M_ARM)
+    __yield();
+#endif
+#elif defined(__GNUC__)
+#if defined(__i386__) || defined(__x86_64__)
+    __asm__ __volatile__("pause;" : : : "memory");
+#elif (defined(__ARM_ARCH) && __ARM_ARCH >= 8) || defined(__ARM_ARCH_8A__) || defined(__aarch64__)
+    __asm__ __volatile__("yield;" : : : "memory");
+#endif
+#endif
+}
+
 namespace mesh {
 
 // logging

--- a/src/common.h
+++ b/src/common.h
@@ -90,8 +90,8 @@ static constexpr size_t kMaxMeshesPerIteration = 2500;
 
 // maximum number of dirty pages to hold onto before we flush them
 // back to the OS (via MeshableArena::scavenge()
-static constexpr size_t kMaxDirtyPageThreshold = 1 << 14;  // 64 MB in pages
-static constexpr size_t kMinDirtyPageThreshold = 32;       // 128 KB in pages
+static constexpr size_t kMaxDirtyPageThreshold = 1 << 16;  // 256 MB in pages
+static constexpr size_t kMinDirtyPageThreshold = 1 << 14;  // 32  MB in pages
 
 static constexpr uint32_t kSpanClassCount = 256;
 
@@ -111,7 +111,7 @@ static constexpr bool kEnableShuffleOnInit = SHUFFLE_ON_INIT == 1;
 static constexpr bool kEnableShuffleOnFree = SHUFFLE_ON_FREE == 1;
 
 // madvise(DONTDUMP) the heap to make reasonable coredumps
-static constexpr bool kAdviseDump = false;
+static constexpr bool kAdviseDump = true;
 
 static constexpr std::chrono::milliseconds kZeroMs{0};
 static constexpr std::chrono::milliseconds kMeshPeriodMs{100};  // 100 ms
@@ -121,7 +121,7 @@ static constexpr size_t kMaxMeshes = 256;  // 1 per bit
 #ifdef __APPLE__
 static constexpr size_t kArenaSize = 32ULL * 1024ULL * 1024ULL * 1024ULL;  // 16 GB
 #else
-static constexpr size_t kArenaSize = 64ULL * 1024ULL * 1024ULL * 1024ULL;  // 64 GB
+static constexpr size_t kArenaSize = 128ULL * 1024ULL * 1024ULL * 1024ULL;  // 128 GB
 #endif
 static constexpr size_t kAltStackSize = 16 * 1024UL;  // 16k sigaltstacks
 #define SIGQUIESCE (SIGRTMIN + 7)

--- a/src/common.h
+++ b/src/common.h
@@ -90,8 +90,8 @@ static constexpr size_t kMaxMeshesPerIteration = 2500;
 
 // maximum number of dirty pages to hold onto before we flush them
 // back to the OS (via MeshableArena::scavenge()
-static constexpr size_t kMaxDirtyPageThreshold = 1 << 16;  // 256 MB in pages
-static constexpr size_t kMinDirtyPageThreshold = 1 << 14;  // 32  MB in pages
+static constexpr size_t kMaxDirtyPageThreshold = 1 << 15;  // 64 MB in pages
+static constexpr size_t kMinDirtyPageThreshold = 1 << 13;  // 16  MB in pages
 
 static constexpr uint32_t kSpanClassCount = 256;
 

--- a/src/common.h
+++ b/src/common.h
@@ -165,6 +165,39 @@ using std::unique_lock;
 #define likely(x) __builtin_expect(!!(x), 1)
 #define unlikely(x) __builtin_expect(!!(x), 0)
 
+
+#ifdef __GNUC__
+  #define GNUC_PREREQ(x, y) \
+      (__GNUC__ > x || (__GNUC__ == x && __GNUC_MINOR__ >= y))
+#else
+  #define GNUC_PREREQ(x, y) 0
+#endif
+
+#ifdef __clang__
+  #define CLANG_PREREQ(x, y) \
+      (__clang_major__ > x || (__clang_major__ == x && __clang_minor__ >= y))
+#else
+  #define CLANG_PREREQ(x, y) 0
+#endif
+
+#if GNUC_PREREQ(4, 2) || \
+    CLANG_PREREQ(3, 0)
+  #define HAVE_ASM_POPCNT
+#endif
+
+#if defined(HAVE_ASM_POPCNT) && \
+    defined(__x86_64__)
+
+static inline uint64_t popcnt64(uint64_t x)
+{
+  __asm__ ("popcnt %1, %0" : "=r" (x) : "0" (x));
+  return x;
+}
+#define popcount64(x) popcnt64(x)
+#else
+#define popcount64(x) __builtin_popcountl(x)
+#endif
+
 #define ATTRIBUTE_UNUSED __attribute__((unused))
 #define ATTRIBUTE_NEVER_INLINE __attribute__((noinline))
 #define ATTRIBUTE_ALWAYS_INLINE __attribute__((always_inline))

--- a/src/global_heap.cc
+++ b/src/global_heap.cc
@@ -87,7 +87,7 @@ void GlobalHeap::freeFor(MiniHeap *mh, void *ptr, size_t startEpoch) {
   // LOCK CMPXCHG in mh->free
   auto remaining = mh->inUseCount() - 1;
 
-  // here can't call mh->free(arenaBegin(), ptr), because in consume takeBitmap always clear the bitmap, 
+  // here can't call mh->free(arenaBegin(), ptr), because in consume takeBitmap always clear the bitmap,
   // if clearIfNotFree after takeBitmap
   // it alwasy return false, but in this case, you need to free again.
   auto wasSet = mh->clearIfNotFree(arenaBegin(), ptr);
@@ -278,7 +278,7 @@ int GlobalHeap::mallctl(const char *name, void *oldp, size_t *oldlenp, void *new
   return 0;
 }
 
-void GlobalHeap::meshLocked(MiniHeap *dst, MiniHeap *&src, internal::vector<Span>& fCmdSpans) {
+void GlobalHeap::meshLocked(MiniHeap *dst, MiniHeap *&src, internal::vector<Span> &fCmdSpans) {
   // mesh::debug("mesh dst:%p <- src:%p\n", dst, src);
   // dst->dumpDebug();
   // src->dumpDebug();
@@ -361,7 +361,7 @@ size_t GlobalHeap::meshSizeClassLocked(size_t sizeClass, MergeSetArray &mergeSet
 
   size_t meshCount = 0;
 
-  internal::FreeCmd* fCommand = new internal::FreeCmd(internal::FreeCmd::FREE_PAGE);
+  internal::FreeCmd *fCommand = new internal::FreeCmd(internal::FreeCmd::FREE_PAGE);
 
   for (size_t i = 0; i < mergeSetCount; i++) {
     std::pair<MiniHeap *, MiniHeap *> &mergeSet = mergeSets[i];

--- a/src/global_heap.cc
+++ b/src/global_heap.cc
@@ -306,6 +306,7 @@ void GlobalHeap::meshLocked(MiniHeap *dst, MiniHeap *&src, internal::vector<Span
   // Super::freePhys(reinterpret_cast<void *>(src->getSpanStart(arenaBegin())), dstSpanSize);
   fCmdSpans.emplace_back(src->span());
 
+  Super::incMeshedSpanCount(dst->span().length);
   // make sure we adjust what bin the destination is in -- it might
   // now be full and not a candidate for meshing
   postFreeLocked(dst, dst->sizeClass(), dst->inUseCount());

--- a/src/global_heap.cc
+++ b/src/global_heap.cc
@@ -379,7 +379,7 @@ size_t GlobalHeap::meshSizeClassLocked(size_t sizeClass, MergeSetArray &mergeSet
     }
   }
 
-  runtime().sendFreeCmd(fCommand);
+  tryAndSendToFree(fCommand);
 
   // flush things once more (since we may have called postFree instead
   // of mesh above)

--- a/src/global_heap.cc
+++ b/src/global_heap.cc
@@ -416,9 +416,9 @@ void GlobalHeap::meshAllSizeClassesLocked() {
     totalMeshCount += meshSizeClassLocked(sizeClass, MergeSets, Left, Right);
   }
 
-  madvise(&Left, sizeof(Left), MADV_DONTNEED);
-  madvise(&Right, sizeof(Right), MADV_DONTNEED);
-  madvise(&MergeSets, sizeof(MergeSets), MADV_DONTNEED);
+  // madvise(&Left, sizeof(Left), MADV_DONTNEED);
+  // madvise(&Right, sizeof(Right), MADV_DONTNEED);
+  // madvise(&MergeSets, sizeof(MergeSets), MADV_DONTNEED);
 
   _lastMeshEffective = totalMeshCount > 256;
   _stats.meshCount += totalMeshCount;

--- a/src/global_heap.cc
+++ b/src/global_heap.cc
@@ -110,7 +110,7 @@ void GlobalHeap::freeFor(MiniHeap *mh, void *ptr, size_t startEpoch) {
 
     if (unlikely(mh != origMh)) {
       hard_assert(!mh->isMeshed());
-      if (mh->isRelated(origMh) && wasSet) {
+      if (mh->isRelated(origMh) && !wasSet) {
         // we have confirmation that we raced with meshing, so free the pointer
         // on the new miniheap
         d_assert(sizeClass == mh->sizeClass());

--- a/src/global_heap.cc
+++ b/src/global_heap.cc
@@ -396,13 +396,12 @@ void GlobalHeap::meshAllSizeClassesLocked() {
   // if we have freed but not reset meshed mappings, this will reset
   // them to the identity mapping, ensuring we don't blow past our VMA
   // limit (which is why we set the force flag to true)
-  Super::scavenge(true);
+  if (Super::aboveMeshThreshold()) {
+    Super::scavenge(true);
+    return;
+  } 
 
   if (!_lastMeshEffective.load(std::memory_order::memory_order_acquire)) {
-    return;
-  }
-
-  if (Super::aboveMeshThreshold()) {
     return;
   }
 

--- a/src/global_heap.cc
+++ b/src/global_heap.cc
@@ -303,6 +303,7 @@ void GlobalHeap::meshLocked(MiniHeap *dst, MiniHeap *&src) {
     Super::finalizeMesh(dstSpanStart, srcSpan, dstSpanSize);
     return false;
   });
+  Super::freePhys(reinterpret_cast<void *>(src->getSpanStart(arenaBegin())), dstSpanSize);
 
   // make sure we adjust what bin the destination is in -- it might
   // now be full and not a candidate for meshing

--- a/src/global_heap.h
+++ b/src/global_heap.h
@@ -213,7 +213,6 @@ public:
     return _emptyFreelist[sizeClass].second > kBinnedTrackerMaxEmpty;
   }
 
-
   inline void releaseMiniheapLocked(MiniHeap *mh, int sizeClass) {
     // ensure this flag is always set with the miniheap lock held
     mh->unsetAttached();
@@ -475,8 +474,8 @@ public:
 
   // PUBLIC ONLY FOR TESTING
   // after call to meshLocked() completes src is a nullptr
-  void ATTRIBUTE_NEVER_INLINE meshLocked(MiniHeap *dst, MiniHeap *&src) {};
-  void ATTRIBUTE_NEVER_INLINE meshLocked(MiniHeap *dst, MiniHeap *&src, internal::vector<Span>& fCmdSpans);
+  void ATTRIBUTE_NEVER_INLINE meshLocked(MiniHeap *dst, MiniHeap *&src){};
+  void ATTRIBUTE_NEVER_INLINE meshLocked(MiniHeap *dst, MiniHeap *&src, internal::vector<Span> &fCmdSpans);
 
   inline void ATTRIBUTE_ALWAYS_INLINE maybeMesh() {
     if (!kMeshingEnabled) {

--- a/src/global_heap.h
+++ b/src/global_heap.h
@@ -456,7 +456,8 @@ public:
 
   // PUBLIC ONLY FOR TESTING
   // after call to meshLocked() completes src is a nullptr
-  void ATTRIBUTE_NEVER_INLINE meshLocked(MiniHeap *dst, MiniHeap *&src);
+  void ATTRIBUTE_NEVER_INLINE meshLocked(MiniHeap *dst, MiniHeap *&src) {};
+  void ATTRIBUTE_NEVER_INLINE meshLocked(MiniHeap *dst, MiniHeap *&src, internal::vector<Span>& fCmdSpans);
 
   inline void ATTRIBUTE_ALWAYS_INLINE maybeMesh() {
     if (!kMeshingEnabled) {

--- a/src/internal.h
+++ b/src/internal.h
@@ -213,7 +213,6 @@ struct Span {
   }
 
   Span() {
-
   }
 
   Span(const Span &rhs) : offset(rhs.offset), length(rhs.length) {
@@ -225,9 +224,8 @@ struct Span {
     return *this;
   }
 
-  bool operator< (const Span &rhs) const
-  {
-      return offset < rhs.offset;
+  bool operator<(const Span &rhs) const {
+    return offset < rhs.offset;
   }
 
   Span(Span &&rhs) : offset(rhs.offset), length(rhs.length) {
@@ -360,7 +358,6 @@ inline void mwcShuffle(_RandomAccessIterator __first, _RandomAccessIterator __la
   }
 }
 
-
 class FreeCmd {
 public:
   enum CmdType {
@@ -371,21 +368,21 @@ public:
     FLUSH,
   };
 
-  FreeCmd(CmdType command):cmd(command) {
-
+  FreeCmd(CmdType command) : cmd(command) {
   }
 
-  void* operator new  ( std::size_t count ) {
-    return mesh::internal::Heap().malloc(count);;
+  void *operator new(std::size_t count) {
+    return mesh::internal::Heap().malloc(count);
+    ;
   }
 
-  void operator delete  ( void* ptr ) throw() {
+  void operator delete(void *ptr) throw() {
     mesh::internal::Heap().free(ptr);
     return;
   }
 
-  internal::vector<Span>  spans;
-  CmdType                 cmd{};
+  internal::vector<Span> spans;
+  CmdType cmd{};
 };
 
 }  // namespace internal

--- a/src/internal.h
+++ b/src/internal.h
@@ -359,6 +359,33 @@ inline void mwcShuffle(_RandomAccessIterator __first, _RandomAccessIterator __la
     }
   }
 }
+
+
+class FreeCmd {
+public:
+  enum CmdType {
+    FREE_PAGE,
+    UNMAP_PAGE,
+    FINISHED_UNMAP_PAGE,
+  };
+
+  FreeCmd(CmdType command):cmd(command) {
+
+  }
+
+  void* operator new  ( std::size_t count ) {
+    return mesh::internal::Heap().malloc(count);;
+  }
+
+  void operator delete  ( void* ptr ) throw() {
+    mesh::internal::Heap().free(ptr);
+    return;
+  }
+
+  internal::vector<Span>  spans;
+  CmdType                 cmd{};
+};
+
 }  // namespace internal
 }  // namespace mesh
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -365,10 +365,10 @@ class FreeCmd {
 public:
   enum CmdType {
     FREE_DIRTY_PAGE,
-    FINISHED_FREE_DIRTY_PAGE,
     FREE_PAGE,
     UNMAP_PAGE,
-    FINISHED_UNMAP_PAGE,
+    CLEAN_PAGE,
+    FLUSH,
   };
 
   FreeCmd(CmdType command):cmd(command) {

--- a/src/internal.h
+++ b/src/internal.h
@@ -212,6 +212,10 @@ struct Span {
   explicit Span(Offset _offset, Length _length) : offset(_offset), length(_length) {
   }
 
+  Span() {
+
+  }
+
   Span(const Span &rhs) : offset(rhs.offset), length(rhs.length) {
   }
 
@@ -253,8 +257,8 @@ struct Span {
     return !(*this == rhs);
   }
 
-  Offset offset;
-  Length length;
+  Offset offset{0};
+  Length length{0};
 };
 
 // keep in-sync with the version in plasma/mesh.h

--- a/src/internal.h
+++ b/src/internal.h
@@ -225,6 +225,11 @@ struct Span {
     return *this;
   }
 
+  bool operator< (const Span &rhs) const
+  {
+      return offset < rhs.offset;
+  }
+
   Span(Span &&rhs) : offset(rhs.offset), length(rhs.length) {
   }
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -364,6 +364,8 @@ inline void mwcShuffle(_RandomAccessIterator __first, _RandomAccessIterator __la
 class FreeCmd {
 public:
   enum CmdType {
+    FREE_DIRTY_PAGE,
+    FINISHED_FREE_DIRTY_PAGE,
     FREE_PAGE,
     UNMAP_PAGE,
     FINISHED_UNMAP_PAGE,

--- a/src/libmesh.cc
+++ b/src/libmesh.cc
@@ -27,13 +27,21 @@ static __attribute__((constructor)) void libmesh_init() {
   }
 
   char *bgThread = getenv("MESH_BACKGROUND_THREAD");
-  if (!bgThread)
-    return;
-
-  int shouldThread = atoi(bgThread);
-  if (shouldThread) {
-    runtime().startBgThread();
+  if (bgThread) {
+    int shouldThread = atoi(bgThread);
+    if (shouldThread) {
+      runtime().startBgThread();
+    }
   }
+
+  // char *bgFreePhysThread = getenv("MESH_FREEPHYS_THREAD");
+  // if (bgFreePhysThread) {
+  //   int shouldFreeThread = atoi(bgFreePhysThread);
+  //   if (shouldFreeThread) {
+  //     runtime().startFreePhysThread();
+  //   }
+  // }
+  runtime().startFreePhysThread();
 }
 
 static __attribute__((destructor)) void libmesh_fini() {

--- a/src/meshable_arena.cc
+++ b/src/meshable_arena.cc
@@ -602,12 +602,6 @@ void MeshableArena::scavenge(bool force) {
 
   tryAndSendToFree(unmapCommand);
 
-  _meshedPageCount = _meshedBitmap.inUseCount();
-  if (_meshedPageCount > _meshedPageCountHWM) {
-    _meshedPageCountHWM = _meshedPageCount;
-    // TODO: find rss at peak
-  }
-
   internal::FreeCmd* freeCommand = new internal::FreeCmd(internal::FreeCmd::FREE_DIRTY_PAGE);
   // dirty page is small, then we don't send the clean page to merge.
 
@@ -900,7 +894,9 @@ void MeshableArena::afterForkChild() {
       seenMiniheaps.insert(mh);
 
       const auto meshCount = mh->meshCount();
-      d_assert(meshCount > 1);
+      if (meshCount == 1) {
+        continue;
+      }
 
       const auto sz = mh->spanSize();
       const auto keep = reinterpret_cast<void *>(mh->getSpanStart(arenaBegin()));

--- a/src/meshable_arena.cc
+++ b/src/meshable_arena.cc
@@ -557,7 +557,7 @@ void MeshableArena::partialScavenge() {
   size_t needFreeCount = 0;
 
   if(_dirtyPageCount > kMaxDirtyPageThreshold) {
-    needFreeCount = (kMaxDirtyPageThreshold - kMinDirtyPageThreshold)/2;
+    needFreeCount = (kMaxDirtyPageThreshold - kMinDirtyPageThreshold)/5;
   }
 
   internal::FreeCmd* freeCommand = new internal::FreeCmd(internal::FreeCmd::FREE_DIRTY_PAGE);
@@ -604,9 +604,13 @@ void MeshableArena::scavenge(bool force) {
 
   internal::FreeCmd* freeCommand = new internal::FreeCmd(internal::FreeCmd::FREE_DIRTY_PAGE);
   // dirty page is small, then we don't send the clean page to merge.
+  size_t needFreeCount = 0;
 
-  size_t freeCount = flushAllSpansToVector(_dirty, freeCommand->spans, _dirtyPageCount);
-  // size_t freeCount = flushSpansToVector(_dirty, freeCommand->spans, needFreeCount);
+  if(_dirtyPageCount > kMaxDirtyPageThreshold) {
+    needFreeCount = (kMaxDirtyPageThreshold - kMinDirtyPageThreshold)/5;
+  }
+  // size_t freeCount = flushAllSpansToVector(_dirty, freeCommand->spans, _dirtyPageCount);
+  size_t freeCount = flushSpansToVector(_dirty, freeCommand->spans, needFreeCount);
   _dirtyPageCount -= freeCount;
 
   tryAndSendToFree(freeCommand);

--- a/src/meshable_arena.cc
+++ b/src/meshable_arena.cc
@@ -857,6 +857,10 @@ void MeshableArena::afterForkChild() {
   void *ptr = mmap(_arenaBegin, kArenaSize, HL_MMAP_PROTECTION_MASK, kMapShared | MAP_FIXED, newFd, 0);
   hard_assert_msg(ptr != MAP_FAILED, "map failed: %d", errno);
 
+  if(kAdviseDump) {
+    madvise(_arenaBegin, kArenaSize, MADV_DONTDUMP);
+  }
+
   // re-do the meshed mappings
   {
     internal::unordered_set<MiniHeap *> seenMiniheaps{};

--- a/src/meshable_arena.cc
+++ b/src/meshable_arena.cc
@@ -492,59 +492,13 @@ void MeshableArena::scavenge(bool force) {
       // debug("getSpansFromBg = %d\n", preDirtySpans->size());
       // all add to the mark spans
       for(auto& s : *preDirtySpans) {
-        spans.emplace_back(s);
+        _clean[s.spanClass()].emplace_back(s);
       }
       deleteFreeSpans(preDirtySpans);
       preDirtySpans = nullptr;
     }
     else {
       break;
-    }
-  }
-
-
-  forEachFree(_clean, [&](const Span &span) {
-    markPages(span);
-  });
-
-  for (size_t i = 0; i < kSpanClassCount; i++) {
-    // debug("_clean[%d] size: %d", i, _clean[i].size());
-    _clean[i].clear();
-  }
-
-  // coalesce adjacent spans
-  struct {
-      bool operator()(const Span& a, const Span& b) const
-      {
-          return a.offset < b.offset;
-      }
-  } spanLess;
-
-  std::sort(spans.begin(), spans.end(), spanLess);
-
-  if(spans.size() > 1) {
-    auto leftIt = spans.begin();
-    auto rightIt = spans.begin() + 1;
-
-    while(rightIt != spans.end()) {
-      d_assert(leftIt->offset + leftIt->length <= rightIt->offset);
-
-      if(leftIt->offset + leftIt->length == rightIt->offset) {
-        leftIt->length += rightIt->length;
-        ++rightIt;
-        continue;
-      }
-      else {
-        _clean[leftIt->spanClass()].emplace_back(leftIt->offset, leftIt->length);
-        leftIt = rightIt;
-        ++rightIt;
-      }
-    }
-    _clean[leftIt->spanClass()].emplace_back(leftIt->offset, leftIt->length);
-  }
-  else {
-    if(spans.size() == 1) {
-      _clean[spans[0].spanClass()].emplace_back(spans[0].offset, spans[0].length);
     }
   }
 }

--- a/src/meshable_arena.cc
+++ b/src/meshable_arena.cc
@@ -525,10 +525,7 @@ void MeshableArena::finalizeMesh(void *keep, void *remove, size_t sz) {
 
   void *ptr = mmap(remove, sz, HL_MMAP_PROTECTION_MASK, kMapShared | MAP_FIXED, _fd, keepOff * kPageSize);
   hard_assert_msg(ptr != MAP_FAILED, "mesh remap failed: %d", errno);
-  freePhys(remove, sz);
 
-  int r = mprotect(remove, sz, PROT_READ | PROT_WRITE);
-  hard_assert(r == 0);
 }
 
 int MeshableArena::openShmSpanFile(size_t sz) {

--- a/src/meshable_arena.cc
+++ b/src/meshable_arena.cc
@@ -144,6 +144,12 @@ void MeshableArena::expandArena(size_t minPagesAdded) {
     abort();
   }
 
+  if (kAdviseDump) {
+    auto ptr = ptrFromOffset(expansion.offset);
+    auto sz = expansion.byteLength();
+    madvise(ptr, sz, MADV_DODUMP);
+  }
+
   _clean[expansion.spanClass()].push_back(expansion);
 }
 
@@ -323,10 +329,6 @@ char *MeshableArena::pageAlloc(Span &result, size_t pageCount, size_t pageAlignm
 #endif
 
   char *ptr = reinterpret_cast<char *>(ptrFromOffset(span.offset));
-
-  if (kAdviseDump) {
-    madvise(ptr, pageCount * kPageSize, MADV_DODUMP);
-  }
 
   result = span;
   return ptr;

--- a/src/meshable_arena.cc
+++ b/src/meshable_arena.cc
@@ -387,6 +387,7 @@ void MeshableArena::scavenge(bool force) {
 
   // now that we've finally reset to identity all delayed-reset
   // mappings, empty the list
+  // debug("_toReset size: %d", _toReset.size());
   _toReset.clear();
 
   _meshedPageCount = _meshedBitmap.inUseCount();
@@ -404,6 +405,7 @@ void MeshableArena::scavenge(bool force) {
   });
 
   for (size_t i = 0; i < kSpanClassCount; i++) {
+    // debug("_dirty[%d] size: %d", i, _dirty[i].size());
     _dirty[i].clear();
   }
 
@@ -414,6 +416,7 @@ void MeshableArena::scavenge(bool force) {
   });
 
   for (size_t i = 0; i < kSpanClassCount; i++) {
+    // debug("_clean[%d] size: %d", i, _clean[i].size());
     _clean[i].clear();
   }
 
@@ -423,9 +426,9 @@ void MeshableArena::scavenge(bool force) {
       {
           return a.offset < b.offset;
       }
-  } customLess;
+  } spanLess;
 
-  std::sort(spans.begin(), spans.end(), customLess);
+  std::sort(spans.begin(), spans.end(), spanLess);
 
   internal::vector<Span> spansMerge;
 
@@ -452,6 +455,8 @@ void MeshableArena::scavenge(bool force) {
   else {
     spansMerge.swap(spans);
   }
+
+  // debug("spansMerge size: %d", spansMerge.size());
 
   for(auto & s: spansMerge) {
     // debug("  spansMerge: %4zu/%4zu\n", s.offset, s.length);

--- a/src/meshable_arena.cc
+++ b/src/meshable_arena.cc
@@ -388,7 +388,7 @@ void MeshableArena::scavenge(bool force) {
 
   // first, untrack the spans in the meshed bitmap and mark them in
   // the (method-local) unallocated bitmap
-  std::for_each(_toReset.begin(), _toReset.end(), [&](Span span) {
+  std::for_each(_toReset.begin(), _toReset.end(), [&](const Span& span) {
     untrackMeshed(span);
     markPages(span);
     resetSpanMapping(span);

--- a/src/meshable_arena.cc
+++ b/src/meshable_arena.cc
@@ -177,8 +177,7 @@ void MeshableArena::expandArena(size_t minPagesAdded) {
   // for(auto& s : _clean[kSpanClassCount-1]) {
   //   debug("clean(%d, %d)", s.offset, s.length);
   // }
-
-  debug("expandArena (minPagesAdded=%d) %d, %d,  dirty : %d\n", minPagesAdded, expansion.offset, expansion.length, _dirtyPageCount);
+  // debug("expandArena (minPagesAdded=%d) %d, %d,  dirty : %d\n", minPagesAdded, expansion.offset, expansion.length, _dirtyPageCount);
 
   _clean[expansion.spanClass()].push_back(expansion);
 
@@ -500,8 +499,7 @@ void MeshableArena::getSpansFromBg(bool flush) {
       else {
         hard_assert(false);
       }
-
-      debug("getSpansFromBg got %d spans -  %d page from backgroud.\n", preCommand->spans.size(), pageCount);
+      // debug("getSpansFromBg got %d spans -  %d page from backgroud.\n", preCommand->spans.size(), pageCount);
       delete preCommand;
     } else {
       break;
@@ -510,23 +508,23 @@ void MeshableArena::getSpansFromBg(bool flush) {
 
   std::sort(_clean[kSpanClassCount-1].begin(), _clean[kSpanClassCount-1].end(), customLess);
 
-  debug("getSpansFromBg after sort last");
-  for(size_t i = 0; i < kSpanClassCount; ++i) {
-    if(!_dirty[i].empty()) {
-      debug("_dirty[%d]  size = %d", i, _dirty[i].size());   
-    }
-  }
+  // debug("getSpansFromBg after sort last");
+  // for(size_t i = 0; i < kSpanClassCount; ++i) {
+  //   if(!_dirty[i].empty()) {
+  //     debug("_dirty[%d]  size = %d", i, _dirty[i].size());
+  //   }
+  // }
 
-  for(size_t i = 0; i < kSpanClassCount; ++i) {
-    if(!_clean[i].empty()) {
-      debug("_clean[%d]  size = %d", i, _clean[i].size());     
-    }
-  }
+  // for(size_t i = 0; i < kSpanClassCount; ++i) {
+  //   if(!_clean[i].empty()) {
+  //     debug("_clean[%d]  size = %d", i, _clean[i].size());
+  //   }
+  // }
 
-  for(auto& s : _clean[kSpanClassCount-1]) {
-    debug("clean(%d, %d)", s.offset, s.length);
-  }
-  debug("getSpansFromBg end");
+  // for(auto& s : _clean[kSpanClassCount-1]) {
+  //   debug("clean(%d, %d)", s.offset, s.length);
+  // }
+  // debug("getSpansFromBg end");
 }
 
 void MeshableArena::partialScavenge() {
@@ -549,7 +547,7 @@ void MeshableArena::partialScavenge() {
 
   runtime().sendFreeCmd(freeCommand);
   runtime().sendFreeCmd(new internal::FreeCmd(internal::FreeCmd::FLUSH));
-  debug("partial FreeCmd::FLUSH");
+  // debug("partial FreeCmd::FLUSH");
   getSpansFromBg();
 }
 
@@ -600,11 +598,11 @@ void MeshableArena::scavenge(bool force) {
     freeCount = flushAllSpansToVector(_clean, cleanCommand->spans, 0);
 
     runtime().sendFreeCmd(cleanCommand);
-    debug("FreeCmd::CLEAN_PAGE");   
+    // debug("FreeCmd::CLEAN_PAGE");
   }
 
   runtime().sendFreeCmd(new internal::FreeCmd(internal::FreeCmd::FLUSH));
-  debug("FreeCmd::FLUSH");
+  // debug("FreeCmd::FLUSH");
 }
 
 void MeshableArena::freePhys(const Span& span) {

--- a/src/meshable_arena.cc
+++ b/src/meshable_arena.cc
@@ -766,6 +766,7 @@ void MeshableArena::prepareForFork() {
   // debug("%d: prepare fork", getpid());
   runtime().heap().lock();
   runtime().lock();
+  internal::Heap().lock();
 
   int r = mprotect(_arenaBegin, kArenaSize, PROT_READ);
   hard_assert(r == 0);
@@ -780,6 +781,8 @@ void MeshableArena::afterForkParent() {
   if (!kMeshingEnabled) {
     return;
   }
+
+  internal::Heap().unlock();
 
   close(_forkPipe[1]);
 
@@ -825,6 +828,7 @@ void MeshableArena::afterForkChild() {
   }
 
   // debug("%d: after fork child", getpid());
+  internal::Heap().unlock();
   runtime().unlock();
   runtime().heap().unlock();
 

--- a/src/meshable_arena.cc
+++ b/src/meshable_arena.cc
@@ -350,7 +350,7 @@ void MeshableArena::partialScavenge() {
   forEachFree(_dirty, [&](const Span &span) {
     auto ptr = ptrFromOffset(span.offset);
     auto sz = span.byteLength();
-    madvise(ptr, sz, MADV_DONTNEED);
+    madvise(ptr, sz, MADV_DONTNEED|MADV_DONTDUMP);
     freePhys(ptr, sz);
     // don't coalesce, just add to clean
     _clean[span.spanClass()].push_back(span);
@@ -412,7 +412,7 @@ void MeshableArena::scavenge(bool force) {
   forEachFree(_dirty, [&](const Span &span) {
     auto ptr = ptrFromOffset(span.offset);
     auto sz = span.byteLength();
-    madvise(ptr, sz, MADV_DONTNEED);
+    madvise(ptr, sz, MADV_DONTNEED|MADV_DONTDUMP);
     freePhys(ptr, sz);
     markPages(span);
   });

--- a/src/meshable_arena.cc
+++ b/src/meshable_arena.cc
@@ -350,7 +350,7 @@ void MeshableArena::partialScavenge() {
   forEachFree(_dirty, [&](const Span &span) {
     auto ptr = ptrFromOffset(span.offset);
     auto sz = span.byteLength();
-    madvise(ptr, sz, MADV_DONTNEED|MADV_DONTDUMP);
+    // madvise(ptr, sz, MADV_DONTNEED|MADV_DONTDUMP);
     freePhys(ptr, sz);
     // don't coalesce, just add to clean
     _clean[span.spanClass()].push_back(span);
@@ -412,7 +412,7 @@ void MeshableArena::scavenge(bool force) {
   forEachFree(_dirty, [&](const Span &span) {
     auto ptr = ptrFromOffset(span.offset);
     auto sz = span.byteLength();
-    madvise(ptr, sz, MADV_DONTNEED|MADV_DONTDUMP);
+    // madvise(ptr, sz, MADV_DONTNEED|MADV_DONTDUMP);
     freePhys(ptr, sz);
     markPages(span);
   });

--- a/src/meshable_arena.cc
+++ b/src/meshable_arena.cc
@@ -463,7 +463,13 @@ void MeshableArena::scavenge(bool force) {
   }
 
   // always flush 1/2 dirty pages, don't flush all of them, or you would flush the same phy page very soon.
-  size_t needFreeCount = (kMaxDirtyPageThreshold - kMinDirtyPageThreshold)/2;
+  size_t needFreeCount = 0;
+  if(_dirtyPageCount > kMaxDirtyPageThreshold) {
+    needFreeCount = (kMaxDirtyPageThreshold - kMinDirtyPageThreshold)/2;
+  }
+  else if (_dirtyPageCount > kMinDirtyPageThreshold) {
+    needFreeCount = _dirtyPageCount - kMinDirtyPageThreshold;
+  }
 
   internal::vector<Span>* dirtyMarkSpans = newFreeSpans();
   hard_assert(dirtyMarkSpans);

--- a/src/meshable_arena.cc
+++ b/src/meshable_arena.cc
@@ -307,7 +307,7 @@ Span MeshableArena::reservePages(const size_t pageCount, const size_t pageAlignm
   Span result(0, 0);
   auto ok = findPages(pageCount, result, flags);
   if (!ok) {
-    getSpansFromBg(true);
+    getSpansFromBg();
     ok = findPages(pageCount, result, flags);
     if (!ok) {
       expandArena(pageCount);
@@ -482,7 +482,7 @@ static size_t flushSpansToVector(internal::vector<Span> freeSpans[kSpanClassCoun
     }   
   } customLess;
 
-void MeshableArena::getSpansFromBg(bool flush) {
+void MeshableArena::getSpansFromBg() {
 
   while(true){
     size_t pageCount = 0;
@@ -528,6 +528,7 @@ void MeshableArena::getSpansFromBg(bool flush) {
 }
 
 void MeshableArena::partialScavenge() {
+   getSpansFromBg();
   // always flush 1/2 pages
   size_t needFreeCount = 0;
 
@@ -548,13 +549,13 @@ void MeshableArena::partialScavenge() {
   runtime().sendFreeCmd(freeCommand);
   runtime().sendFreeCmd(new internal::FreeCmd(internal::FreeCmd::FLUSH));
   // debug("partial FreeCmd::FLUSH");
-  getSpansFromBg();
 }
 
 void MeshableArena::scavenge(bool force) {
   if (!force && _dirtyPageCount < kMinDirtyPageThreshold) {
     return;
   }
+  getSpansFromBg();
 
   internal::FreeCmd* unmapCommand = new internal::FreeCmd(internal::FreeCmd::UNMAP_PAGE);
 

--- a/src/meshable_arena.cc
+++ b/src/meshable_arena.cc
@@ -867,7 +867,7 @@ void MeshableArena::afterForkChild() {
 
     for (auto const &i : _meshedBitmap) {
       MiniHeap *mh = reinterpret_cast<MiniHeap *>(miniheapForArenaOffset(i));
-      if (seenMiniheaps.find(mh) != seenMiniheaps.end()) {
+      if (!mh || seenMiniheaps.find(mh) != seenMiniheaps.end()) {
         continue;
       }
       seenMiniheaps.insert(mh);

--- a/src/meshable_arena.h
+++ b/src/meshable_arena.h
@@ -142,7 +142,7 @@ public:
 
   void doAfterForkChild();
 
-  void freePhys(const Span& span);
+  void freePhys(const Span &span);
   void freePhys(void *ptr, size_t sz);
 
   inline void resetSpanMapping(const Span &span) {
@@ -166,8 +166,7 @@ public:
 private:
   void expandArena(size_t minPagesAdded);
   bool findPages(size_t pageCount, Span &result, internal::PageType &type);
-  bool findPagesInnerFast(internal::vector<Span> freeSpans[kSpanClassCount], size_t i,
-                                             size_t pageCount, Span &result);
+  bool findPagesInnerFast(internal::vector<Span> freeSpans[kSpanClassCount], size_t i, size_t pageCount, Span &result);
   bool ATTRIBUTE_NEVER_INLINE findPagesInner(internal::vector<Span> freeSpans[kSpanClassCount], size_t i,
                                              size_t pageCount, Span &result);
   Span reservePages(size_t pageCount, size_t pageAlignment);
@@ -191,10 +190,10 @@ private:
     }
   }
 
-  void moveBiggerTofirst(internal::vector<Span>& spans) {
-    if(spans.size() > 1) {
-      if(spans[0].length > spans[spans.size()-1].length) {
-        std::swap(spans[0], spans[spans.size()-1]);
+  void moveBiggerTofirst(internal::vector<Span> &spans) {
+    if (spans.size() > 1) {
+      if (spans[0].length > spans[spans.size() - 1].length) {
+        std::swap(spans[0], spans[spans.size() - 1]);
       }
     }
   }
@@ -299,7 +298,7 @@ private:
 
 protected:
   void getSpansFromBg(bool wait = false);
-  void tryAndSendToFree(internal::FreeCmd* fCommand);
+  void tryAndSendToFree(internal::FreeCmd *fCommand);
   CheapHeap<64, kArenaSize / kPageSize> _mhAllocator{};
   MWC _fastPrng;
 

--- a/src/meshable_arena.h
+++ b/src/meshable_arena.h
@@ -142,17 +142,6 @@ public:
 
   void doAfterForkChild();
 
-  internal::vector<Span>* newFreeSpans() {
-    void* buf = internal::Heap().malloc(sizeof(internal::vector<Span>));
-    internal::vector<Span>* freeSpans = new (buf) internal::vector<Span>();
-    return freeSpans;
-  }
-
-  void deleteFreeSpans(internal::vector<Span>* spans) {
-    spans->~vector();
-    internal::Heap().free(spans);
-  }
-
   void freePhys(const Span& span);
   void freePhys(void *ptr, size_t sz);
 

--- a/src/meshable_arena.h
+++ b/src/meshable_arena.h
@@ -187,7 +187,7 @@ private:
     }
   }
 
-  void getSpansFromBg(bool flush = false);
+  void getSpansFromBg();
 
   inline void freeSpan(const Span &span, const internal::PageType flags) {
     if (span.length == 0) {

--- a/src/meshable_arena.h
+++ b/src/meshable_arena.h
@@ -184,9 +184,9 @@ private:
     clearIndex(span);
 
     if (flags == internal::PageType::Dirty) {
-      if (kAdviseDump) {
-        madvise(ptrFromOffset(span.offset), span.length * kPageSize, MADV_DONTDUMP);
-      }
+      // if (kAdviseDump) {
+      //   madvise(ptrFromOffset(span.offset), span.length * kPageSize, MADV_DONTDUMP);
+      // }
       d_assert(span.length > 0);
       _dirty[span.spanClass()].push_back(span);
       _dirtyPageCount += span.length;

--- a/src/meshable_arena.h
+++ b/src/meshable_arena.h
@@ -155,6 +155,13 @@ public:
 
   void freePhys(const Span& span);
   void freePhys(void *ptr, size_t sz);
+
+  inline void resetSpanMapping(const Span &span) {
+    auto ptr = ptrFromOffset(span.offset);
+    auto sz = span.byteLength();
+    mmap(ptr, sz, HL_MMAP_PROTECTION_MASK, kMapShared | MAP_FIXED, _fd, span.offset * kPageSize);
+  }
+
 private:
   void expandArena(size_t minPagesAdded);
   bool findPages(size_t pageCount, Span &result, internal::PageType &type);
@@ -266,12 +273,6 @@ private:
       d_assert(_meshedBitmap.isSet(span.offset + i));
       _meshedBitmap.unset(span.offset + i);
     }
-  }
-
-  inline void resetSpanMapping(const Span &span) {
-    auto ptr = ptrFromOffset(span.offset);
-    auto sz = span.byteLength();
-    mmap(ptr, sz, HL_MMAP_PROTECTION_MASK, kMapShared | MAP_FIXED, _fd, span.offset * kPageSize);
   }
 
   void prepareForFork();

--- a/src/meshable_arena.h
+++ b/src/meshable_arena.h
@@ -142,13 +142,13 @@ public:
 
   void doAfterForkChild();
 
+  void freePhys(void *ptr, size_t sz);
 private:
   void expandArena(size_t minPagesAdded);
   bool findPages(size_t pageCount, Span &result, internal::PageType &type);
   bool ATTRIBUTE_NEVER_INLINE findPagesInner(internal::vector<Span> freeSpans[kSpanClassCount], size_t i,
                                              size_t pageCount, Span &result);
   Span reservePages(size_t pageCount, size_t pageAlignment);
-  void freePhys(void *ptr, size_t sz);
   internal::RelaxedBitmap allocatedBitmap(bool includeDirty = true) const;
 
   void *malloc(size_t sz) = delete;

--- a/src/meshable_arena.h
+++ b/src/meshable_arena.h
@@ -187,8 +187,6 @@ private:
     }
   }
 
-  void getSpansFromBg();
-
   inline void freeSpan(const Span &span, const internal::PageType flags) {
     if (span.length == 0) {
       return;
@@ -287,6 +285,8 @@ private:
   atomic<MiniHeapID> *_mhIndex{nullptr};
 
 protected:
+  void getSpansFromBg(bool wait = false);
+  void tryAndSendToFree(internal::FreeCmd* fCommand);
   CheapHeap<64, kArenaSize / kPageSize> _mhAllocator{};
   MWC _fastPrng;
 

--- a/src/mini_heap.h
+++ b/src/mini_heap.h
@@ -168,7 +168,7 @@ public:
     // dumpDebug();
   }
 
-  inline const Span& span() const {
+  inline const Span &span() const {
     return _span;
   }
 
@@ -236,7 +236,7 @@ public:
 
     auto mh = NextMeshedMiniHeap();
     if (mh) {
-      mh->takeBitmap(); // rewrite it with clear?
+      mh->takeBitmap();  // rewrite it with clear?
     } else {
       srcBitmap.invert();
       uint32_t max = maxCount();
@@ -392,7 +392,7 @@ public:
   }
 
 public:
-  inline MiniHeap* NextMeshedMiniHeap() const {
+  inline MiniHeap *NextMeshedMiniHeap() const {
     if (_nextMeshed.hasValue()) {
       return GetMiniHeap(_nextMeshed);
     }

--- a/src/mini_heap.h
+++ b/src/mini_heap.h
@@ -168,7 +168,7 @@ public:
     // dumpDebug();
   }
 
-  inline Span span() const {
+  inline const Span& span() const {
     return _span;
   }
 

--- a/src/mini_heap.h
+++ b/src/mini_heap.h
@@ -192,7 +192,6 @@ public:
   }
 
   inline bool clearIfNotFree(void *arenaBegin, void *ptr) {
-    d_assert(isMeshed());
     const ssize_t off = getOff(arenaBegin, ptr);
     const auto notWasSet = _bitmap.unset(off);
     const auto wasSet = !notWasSet;

--- a/src/mpsc_buffer.h
+++ b/src/mpsc_buffer.h
@@ -7,101 +7,92 @@
 #include <type_traits>
 #include "internal.h"
 
-namespace mesh
-{
+namespace mesh {
 
-constexpr bool is_power_two(int N)
-{
-	return ((N & (N-1)) == 0);
+constexpr bool is_power_two(int N) {
+  return ((N & (N - 1)) == 0);
 }
 
 static constexpr std::size_t g_ring_buffer_size = 1024;
 
-template<typename Ptr>
-class alignas(64) ring_buffer
-{
+template <typename Ptr>
+class alignas(64) ring_buffer {
 public:
-	static_assert(std::is_pointer<Ptr>::value, "buffer item should be a pointer");
+  static_assert(std::is_pointer<Ptr>::value, "buffer item should be a pointer");
 
-	using index_type = std::int64_t;
-	using value_type = std::atomic<Ptr>;
-	using cursor_type = std::atomic<index_type>;
-	using buffer_type = internal::vector<value_type>;
+  using index_type = std::int64_t;
+  using value_type = std::atomic<Ptr>;
+  using cursor_type = std::atomic<index_type>;
+  using buffer_type = internal::vector<value_type>;
 
-	ring_buffer(index_type arity=g_ring_buffer_size)
-		: m_pptr(0), m_gptr(0), m_arity(arity)
-		, m_mask(arity - 1), m_buffer(arity)
-	{
-		for(value_type &v : m_buffer)
-			v.store(nullptr, std::memory_order_release);
-	}
+  ring_buffer(index_type arity = g_ring_buffer_size)
+      : m_pptr(0), m_gptr(0), m_arity(arity), m_mask(arity - 1), m_buffer(arity) {
+    for (value_type &v : m_buffer)
+      v.store(nullptr, std::memory_order_release);
+  }
 
 public:
-	inline void push(Ptr p)
-	{
-		index_type inx = m_pptr.fetch_add(1);
-		while((inx - m_arity) >= m_gptr.load(std::memory_order_acquire))
-			std::this_thread::yield();
-		get(inx).store(p, std::memory_order_release);
-	}
-	inline bool try_push(Ptr p)
-	{
-			index_type ginx = m_gptr.load(std::memory_order_acquire);
-			index_type pinx = m_pptr.load(std::memory_order_acquire);
-			if((pinx - ginx) >= m_arity)
-					return false;
-			push(p);
-			return true;
-	}
-	inline Ptr pop()
-	{
-		index_type ginx = m_gptr.load(std::memory_order_acquire);
-		index_type pinx = m_pptr.load(std::memory_order_acquire);
-		if(ginx >= pinx)
-			return nullptr;
-		value_type &v = get(ginx);
-		Ptr vp;
-		while(!(vp = v.exchange(nullptr)));
-		m_gptr.store(ginx + 1, std::memory_order_release);
-		return vp;
-	}
-	inline std::size_t pop(std::vector<Ptr> &op)
-	{
-		index_type ginx = m_gptr.load(std::memory_order_acquire);
-		index_type pinx = m_pptr.load(std::memory_order_acquire);
-		if(ginx >= pinx)
-			return 0;
-		if(pinx >= ginx + m_arity)
-			pinx = ginx + m_arity;
-		Ptr vp;
-		for(index_type inx = ginx; inx < pinx; ++inx)
-		{
-			value_type &v = get(inx);
-			while(!(vp = v.exchange(nullptr)));
-			op.emplace_back(vp);
-		}
-		m_gptr.store(pinx, std::memory_order_release);
-		return pinx - ginx;
-	}
+  inline void push(Ptr p) {
+    index_type inx = m_pptr.fetch_add(1);
+    while ((inx - m_arity) >= m_gptr.load(std::memory_order_acquire))
+      std::this_thread::yield();
+    get(inx).store(p, std::memory_order_release);
+  }
+  inline bool try_push(Ptr p) {
+    index_type ginx = m_gptr.load(std::memory_order_acquire);
+    index_type pinx = m_pptr.load(std::memory_order_acquire);
+    if ((pinx - ginx) >= m_arity)
+      return false;
+    push(p);
+    return true;
+  }
+  inline Ptr pop() {
+    index_type ginx = m_gptr.load(std::memory_order_acquire);
+    index_type pinx = m_pptr.load(std::memory_order_acquire);
+    if (ginx >= pinx)
+      return nullptr;
+    value_type &v = get(ginx);
+    Ptr vp;
+    while (!(vp = v.exchange(nullptr)))
+      ;
+    m_gptr.store(ginx + 1, std::memory_order_release);
+    return vp;
+  }
+  inline std::size_t pop(std::vector<Ptr> &op) {
+    index_type ginx = m_gptr.load(std::memory_order_acquire);
+    index_type pinx = m_pptr.load(std::memory_order_acquire);
+    if (ginx >= pinx)
+      return 0;
+    if (pinx >= ginx + m_arity)
+      pinx = ginx + m_arity;
+    Ptr vp;
+    for (index_type inx = ginx; inx < pinx; ++inx) {
+      value_type &v = get(inx);
+      while (!(vp = v.exchange(nullptr)))
+        ;
+      op.emplace_back(vp);
+    }
+    m_gptr.store(pinx, std::memory_order_release);
+    return pinx - ginx;
+  }
 
-	inline std::size_t size() const
-	{
-		return m_buffer.size();
-	}
+  inline std::size_t size() const {
+    return m_buffer.size();
+  }
+
 private:
-	inline value_type & get(index_type inx)
-	{
-		return m_buffer[inx & m_mask];
-	}
+  inline value_type &get(index_type inx) {
+    return m_buffer[inx & m_mask];
+  }
 
-	cursor_type		m_pptr;
-	char			m_padding_1[64-sizeof(cursor_type)];
-	cursor_type		m_gptr;
-	char			m_padding_2[64-sizeof(cursor_type)];
-	index_type		m_arity;
-	index_type		m_mask;
-	char			m_padding_3[64-sizeof(index_type)*2];
-	buffer_type		m_buffer;
+  cursor_type m_pptr;
+  char m_padding_1[64 - sizeof(cursor_type)];
+  cursor_type m_gptr;
+  char m_padding_2[64 - sizeof(cursor_type)];
+  index_type m_arity;
+  index_type m_mask;
+  char m_padding_3[64 - sizeof(index_type) * 2];
+  buffer_type m_buffer;
 };
 
-}
+}  // namespace mesh

--- a/src/mpsc_buffer.h
+++ b/src/mpsc_buffer.h
@@ -46,10 +46,11 @@ public:
 	}
 	inline bool try_push(Ptr p)
 	{
-			index_type inx = m_pptr.fetch_add(1);
-			if((inx - m_arity) >= m_gptr.load(std::memory_order_acquire))
+			index_type ginx = m_gptr.load(std::memory_order_acquire);
+			index_type pinx = m_pptr.load(std::memory_order_acquire);
+			if((pinx - ginx) >= m_arity)
 					return false;
-			get(inx).store(p, std::memory_order_release);
+			push(p);
 			return true;
 	}
 	inline Ptr pop()

--- a/src/mpsc_buffer.h
+++ b/src/mpsc_buffer.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <array>
+#include <thread>
+#include <atomic>
+#include <cstdint>
+#include <type_traits>
+#include "internal.h"
+
+namespace mesh
+{
+
+constexpr bool is_power_two(int N)
+{
+	return ((N & (N-1)) == 0);
+}
+
+static constexpr std::size_t g_ring_buffer_size = 1024;
+
+template<typename Ptr>
+class alignas(64) ring_buffer
+{
+public:
+	static_assert(std::is_pointer<Ptr>::value, "buffer item should be a pointer");
+
+	using index_type = std::int64_t;
+	using value_type = std::atomic<Ptr>;
+	using cursor_type = std::atomic<index_type>;
+	using buffer_type = internal::vector<value_type>;
+
+	ring_buffer(index_type arity=g_ring_buffer_size)
+		: m_pptr(0), m_gptr(0), m_arity(arity)
+		, m_mask(arity - 1), m_buffer(arity)
+	{
+		for(value_type &v : m_buffer)
+			v.store(nullptr, std::memory_order_release);
+	}
+
+public:
+	inline void push(Ptr p)
+	{
+		index_type inx = m_pptr.fetch_add(1);
+		while((inx - m_arity) >= m_gptr.load(std::memory_order_acquire))
+			std::this_thread::yield();
+		get(inx).store(p, std::memory_order_release);
+	}
+	inline Ptr pop()
+	{
+		index_type ginx = m_gptr.load(std::memory_order_acquire);
+		index_type pinx = m_pptr.load(std::memory_order_acquire);
+		if(ginx >= pinx)
+			return nullptr;
+		value_type &v = get(ginx);
+		Ptr vp;
+		while(!(vp = v.exchange(nullptr)));
+		m_gptr.store(ginx + 1, std::memory_order_release);
+		return vp;
+	}
+	inline std::size_t pop(std::vector<Ptr> &op)
+	{
+		index_type ginx = m_gptr.load(std::memory_order_acquire);
+		index_type pinx = m_pptr.load(std::memory_order_acquire);
+		if(ginx >= pinx)
+			return 0;
+		if(pinx >= ginx + m_arity)
+			pinx = ginx + m_arity;
+		Ptr vp;
+		for(index_type inx = ginx; inx < pinx; ++inx)
+		{
+			value_type &v = get(inx);
+			while(!(vp = v.exchange(nullptr)));
+			op.emplace_back(vp);
+		}
+		m_gptr.store(pinx, std::memory_order_release);
+		return pinx - ginx;
+	}
+
+	inline std::size_t size() const
+	{
+		return m_buffer.size();
+	}
+private:
+	inline value_type & get(index_type inx)
+	{
+		return m_buffer[inx & m_mask];
+	}
+
+	cursor_type		m_pptr;
+	char			m_padding_1[64-sizeof(cursor_type)];
+	cursor_type		m_gptr;
+	char			m_padding_2[64-sizeof(cursor_type)];
+	index_type		m_arity;
+	index_type		m_mask;
+	char			m_padding_3[64-sizeof(index_type)*2];
+	buffer_type		m_buffer;
+};
+
+}

--- a/src/mpsc_buffer.h
+++ b/src/mpsc_buffer.h
@@ -44,6 +44,14 @@ public:
 			std::this_thread::yield();
 		get(inx).store(p, std::memory_order_release);
 	}
+	inline bool try_push(Ptr p)
+	{
+			index_type inx = m_pptr.fetch_add(1);
+			if((inx - m_arity) >= m_gptr.load(std::memory_order_acquire))
+					return false;
+			get(inx).store(p, std::memory_order_release);
+			return true;
+	}
 	inline Ptr pop()
 	{
 		index_type ginx = m_gptr.load(std::memory_order_acquire);

--- a/src/partitioned_heap.h
+++ b/src/partitioned_heap.h
@@ -17,7 +17,7 @@
 namespace mesh {
 
 static constexpr int kPartitionedHeapNBins = 16;
-static constexpr int kPartitionedHeapArenaSize = 2000 * 1024 * 1024; // 2000 MB
+static constexpr int kPartitionedHeapArenaSize = 2000 * 1024 * 1024;  // 2000 MB
 static constexpr int kPartitionedHeapSizePer = kPartitionedHeapArenaSize / kPartitionedHeapNBins;
 
 // Fast allocation for multiple size classes

--- a/src/partitioned_heap.h
+++ b/src/partitioned_heap.h
@@ -17,7 +17,7 @@
 namespace mesh {
 
 static constexpr int kPartitionedHeapNBins = 16;
-static constexpr int kPartitionedHeapArenaSize = 512 * 1024 * 1024;  // 512 MB
+static constexpr int kPartitionedHeapArenaSize = 2000 * 1024 * 1024; // 2000 MB
 static constexpr int kPartitionedHeapSizePer = kPartitionedHeapArenaSize / kPartitionedHeapNBins;
 
 // Fast allocation for multiple size classes
@@ -56,11 +56,13 @@ public:
     if (unlikely(sizeClass >= kPartitionedHeapNBins)) {
       auto res = _bigHeap.malloc(sz);
       // debug("internalHeap::malloc(%zu): %p (big)\n", sz, res);
+      hard_assert(res);
       return res;
     }
 
     auto res = _smallHeaps[sizeClass].alloc();
     // debug("internalHeap::malloc(%zu): %p\n", sz, res);
+    hard_assert(res);
     return res;
   }
 

--- a/src/partitioned_heap.h
+++ b/src/partitioned_heap.h
@@ -35,6 +35,11 @@ public:
     auto freelist = reinterpret_cast<char *>(SuperHeap::malloc(kPartitionedHeapArenaSize));
     hard_assert(freelist != nullptr);
 
+    if (kAdviseDump) {
+      madvise(_smallArena, kPartitionedHeapArenaSize, MADV_DONTDUMP);
+      madvise(freelist, kPartitionedHeapArenaSize, MADV_DONTDUMP);
+    }
+
     for (size_t i = 0; i < kPartitionedHeapNBins; ++i) {
       auto arenaStart = _smallArena + i * kPartitionedHeapSizePer;
       auto freelistStart = freelist + i * kPartitionedHeapSizePer;

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -372,7 +372,7 @@ bool Runtime::jobFreeCmd() {
           pageCount += span.length;
           #endif
         }
-        rt.expandFlushSpans(fCommand->spans);
+        rt.expandFlushSpans(fCommand->spans, false);
         // debug("UNMAP_PAGE: %d spans,  pageCount = %d\n", fCommand->spans.size(), pageCount);
         delete fCommand;
         break;
@@ -380,6 +380,8 @@ bool Runtime::jobFreeCmd() {
 
     case internal::FreeCmd::FREE_DIRTY_PAGE:
       {
+        std::sort(fCommand->spans.begin(), fCommand->spans.end());
+        mergeSpans(fCommand->spans);
         for( auto& span : fCommand->spans) {
           rt.heap().freePhys(span);
           #ifndef NDEBUG
@@ -387,7 +389,7 @@ bool Runtime::jobFreeCmd() {
           #endif
         }
 
-        rt.expandFlushSpans(fCommand->spans);
+        rt.expandFlushSpans(fCommand->spans, true);
         // debug("FREE_DIRTY_PAGE: %d spans,  pageCount = %d\n", fCommand->spans.size(), pageCount);
         delete fCommand;
         break;
@@ -400,7 +402,7 @@ bool Runtime::jobFreeCmd() {
         }
         #endif
 
-        rt.expandFlushSpans(fCommand->spans);
+        rt.expandFlushSpans(fCommand->spans, false);
         // debug("CLEAN_PAGE: %d spans,  pageCount = %d\n", fCommand->spans.size(), pageCount);
         delete fCommand;
         break;

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -284,6 +284,7 @@ void *Runtime::bgFreePhysThread(void *arg) {
 
   // debug("libmesh: freePhys thread started\n");
 
+  size_t idle = 0;
   while(true) {
     auto spans = rt._spansFreeBuffer->pop();
 
@@ -295,9 +296,16 @@ void *Runtime::bgFreePhysThread(void *arg) {
       }
       // debug("bgFreePhysThread free: %d\n", pageCount);
       rt._spansReturnBuffer->push(spans);
+      idle = 0;
     }
     else {
-      std::this_thread::sleep_for(10ms);
+      if(idle > 10) {
+        std::this_thread::sleep_for(10ms);
+      }
+      else {
+        std::this_thread::sleep_for(1ms);
+        ++idle;       
+      }
     }
   }
 

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -287,10 +287,13 @@ void *Runtime::bgFreePhysThread(void *arg) {
   while(true) {
     auto spans = rt._spansFreeBuffer->pop();
 
+    size_t pageCount = 0;
     if(spans) {
       for( auto& span : *spans) {
         rt.heap().freePhys(span);
+        pageCount += span.length;
       }
+      // debug("bgFreePhysThread free: %d\n", pageCount);
       rt._spansReturnBuffer->push(spans);
     }
     else {

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -65,11 +65,10 @@ size_t internal::measurePssKiB() {
 }
 
 #if defined(__linux__) || defined(__linux)
-inline void change_thread_name(const char* postfix, int index=-1)
+inline static void change_thread_name(const char* postfix, int index=-1)
 {
-	static char process_name[16];
-	static std::once_flag init_flag;
-	std::call_once(init_flag, prctl, PR_GET_NAME, (unsigned long)process_name, 0, 0, 0);
+	char process_name[16];
+	prctl(PR_GET_NAME, (unsigned long)process_name, 0, 0, 0);
 	char new_name[16];
 #ifdef __GNUC__
 #pragma GCC diagnostic push
@@ -246,7 +245,7 @@ void Runtime::startBgThread() {
 }
 
 void *Runtime::bgThread(void *arg) {
-  change_thread_name("background");
+  change_thread_name("bg");
 
   auto &rt = mesh::runtime();
   // debug("libmesh: background thread started\n");
@@ -430,7 +429,7 @@ bool Runtime::jobFreeCmd() {
 }
 
 void *Runtime::bgFreePhysThread(void *arg) {
-  change_thread_name("FreePhys");
+  change_thread_name("mesh");
 
   auto &rt = mesh::runtime();
 

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -282,7 +282,7 @@ void *Runtime::bgFreePhysThread(void *arg) {
   auto &rt = mesh::runtime();
   using namespace std::chrono_literals;
 
-  debug("libmesh: freePhys thread started\n");
+  // debug("libmesh: freePhys thread started\n");
 
   while(true) {
     auto spans = rt._spansFreeBuffer->pop();

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -102,11 +102,13 @@ public:
     return _pagesReturnCmdBuffer->pop();
   }
 
-  void expandFlushSpans(internal::vector<Span>& spans) {
+  void expandFlushSpans(internal::vector<Span>& spans, bool sorted) {
     internal::vector<Span> tmp;
     tmp.reserve(_flushSpans.size() + spans.size());
 
-    std::sort(spans.begin(), spans.end());
+    if(!sorted) {
+      std::sort(spans.begin(), spans.end());
+    }
 
     std::merge(_flushSpans.begin(), _flushSpans.end(), spans.begin(), spans.end(), std::back_inserter(tmp));
 

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -27,8 +27,8 @@ namespace mesh {
 // function passed to pthread_create
 typedef void *(*PthreadFn)(void *);
 
-typedef ring_buffer<internal::vector<Span>*>  FreeRingVector;
-typedef ring_buffer<internal::FreeCmd*>       FreeCmdRingVector;
+typedef ring_buffer<internal::vector<Span> *> FreeRingVector;
+typedef ring_buffer<internal::FreeCmd *> FreeCmdRingVector;
 
 class Runtime {
 private:
@@ -90,23 +90,22 @@ public:
     return _pid;
   }
 
-  bool sendFreeCmd(internal::FreeCmd* fComand) {
+  bool sendFreeCmd(internal::FreeCmd *fComand) {
     return _pagesFreeCmdBuffer->try_push(fComand);
   }
 
   void selfFlush() {
-
   }
 
-  internal::FreeCmd* getReturnCmdFromBg() {
+  internal::FreeCmd *getReturnCmdFromBg() {
     return _pagesReturnCmdBuffer->pop();
   }
 
-  void expandFlushSpans(internal::vector<Span>& spans, bool sorted) {
+  void expandFlushSpans(internal::vector<Span> &spans, bool sorted) {
     internal::vector<Span> tmp;
     tmp.reserve(_flushSpans.size() + spans.size());
 
-    if(!sorted) {
+    if (!sorted) {
       std::sort(spans.begin(), spans.end());
     }
 
@@ -115,11 +114,13 @@ public:
     _flushSpans.swap(tmp);
   }
 
-  internal::vector<Span>& getFlushSpans() {
+  internal::vector<Span> &getFlushSpans() {
     return _flushSpans;
   }
 
-  bool freeThreadRunning() const { return _freeThreadRunning; }
+  bool freeThreadRunning() const {
+    return _freeThreadRunning;
+  }
 
 protected:
   bool jobFreeCmd();
@@ -144,9 +145,9 @@ private:
   pid_t _pid{};
   GlobalHeap _heap{};
 
-  FreeCmdRingVector* _pagesFreeCmdBuffer{nullptr};
-  FreeCmdRingVector* _pagesReturnCmdBuffer{nullptr};
-  internal::vector<Span>  _flushSpans;
+  FreeCmdRingVector *_pagesFreeCmdBuffer{nullptr};
+  FreeCmdRingVector *_pagesReturnCmdBuffer{nullptr};
+  internal::vector<Span> _flushSpans;
   bool _freeThreadRunning{false};
 };
 
@@ -157,8 +158,6 @@ inline Runtime &runtime() {
   static Runtime *runtimePtr = new (buf) Runtime{};
   return *runtimePtr;
 }
-
-
 
 }  // namespace mesh
 

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -99,18 +99,14 @@ public:
   }
 
   void expandFlushSpans(internal::vector<Span>& spans) {
-    _flushSpans.reserve(_flushSpans.size() + spans.size());
+    internal::vector<Span> tmp;
+    tmp.reserve(_flushSpans.size() + spans.size());
 
     std::sort(spans.begin(), spans.end());
-    auto first = _flushSpans.begin();
-    auto middle = _flushSpans.end();
-    
-    for( auto& s : spans) {
-      _flushSpans.emplace_back(s);
-    }
 
-    auto last = _flushSpans.end();
-    std::inplace_merge(first, middle, last);
+    std::merge(_flushSpans.begin(), _flushSpans.end(), spans.begin(), spans.end(), std::back_inserter(tmp));
+
+    _flushSpans.swap(tmp);
   }
 
   internal::vector<Span>& getFlushSpans() {

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -97,8 +97,18 @@ public:
     return _pagesReturnCmdBuffer->pop();
   }
 
+  void expandFlushSpans(internal::vector<Span>& spans) {
+    _flushSpans.reserve(_flushSpans.size() + spans.size());
+    for( auto& s : spans) {
+      _flushSpans.emplace_back(s);
+    }
+  }
+
+  internal::vector<Span>& getFlushSpans() {
+    return _flushSpans;
+  }
+
 protected:
-  void jobFreePhysSpans(internal::FreeCmd* fComand);
   bool jobFreeCmd();
 
 private:
@@ -122,6 +132,7 @@ private:
 
   FreeCmdRingVector* _pagesFreeCmdBuffer{nullptr};
   FreeCmdRingVector* _pagesReturnCmdBuffer{nullptr};
+  internal::vector<Span>  _flushSpans;
 };
 
 // get a reference to the Runtime singleton

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -89,14 +89,6 @@ public:
     return _pid;
   }
 
-  void freeSpansBg(internal::vector<Span>* spans) {
-    _spansFreeBuffer->push(spans);
-  }
-
-  internal::vector<Span>* getSpansFromBg() {
-    return _spansReturnBuffer->pop();
-  }
-
   void sendFreeCmd(internal::FreeCmd* fComand) {
     _pagesFreeCmdBuffer->push(fComand);
   }
@@ -106,7 +98,7 @@ public:
   }
 
 protected:
-  bool jobFreePhysSpans();
+  void jobFreePhysSpans(internal::FreeCmd* fComand);
   bool jobFreeCmd();
 
 private:

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -96,6 +96,9 @@ public:
     return _spansReturnBuffer->pop();
   }
 
+protected:
+  bool jobFreePhysSpans();
+
 private:
   // initialize our pointer to libc's pthread_create, etc.  This
   // happens lazily, as the dynamic linker's dlopen calls into malloc

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -9,6 +9,7 @@
 
 #include <pthread.h>
 #include <thread>
+#include <algorithm>
 #include <signal.h>  // for stack_t
 
 #include "internal.h"
@@ -99,9 +100,17 @@ public:
 
   void expandFlushSpans(internal::vector<Span>& spans) {
     _flushSpans.reserve(_flushSpans.size() + spans.size());
+
+    std::sort(spans.begin(), spans.end());
+    auto first = _flushSpans.begin();
+    auto middle = _flushSpans.end();
+    
     for( auto& s : spans) {
       _flushSpans.emplace_back(s);
     }
+
+    auto last = _flushSpans.end();
+    std::inplace_merge(first, middle, last);
   }
 
   internal::vector<Span>& getFlushSpans() {

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -120,9 +120,6 @@ private:
   pid_t _pid{};
   GlobalHeap _heap{};
 
-  FreeRingVector* _spansFreeBuffer{nullptr};
-  FreeRingVector* _spansReturnBuffer{nullptr};
-
   FreeCmdRingVector* _pagesFreeCmdBuffer{nullptr};
   FreeCmdRingVector* _pagesReturnCmdBuffer{nullptr};
 };

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -26,7 +26,8 @@ namespace mesh {
 // function passed to pthread_create
 typedef void *(*PthreadFn)(void *);
 
-typedef ring_buffer<internal::vector<Span>*> FreeRingVector;
+typedef ring_buffer<internal::vector<Span>*>  FreeRingVector;
+typedef ring_buffer<internal::FreeCmd*>       FreeCmdRingVector;
 
 class Runtime {
 private:
@@ -96,8 +97,17 @@ public:
     return _spansReturnBuffer->pop();
   }
 
+  void sendFreeCmd(internal::FreeCmd* fComand) {
+    _pagesFreeCmdBuffer->push(fComand);
+  }
+
+  internal::FreeCmd* getReturnCmdFromBg() {
+    return _pagesReturnCmdBuffer->pop();
+  }
+
 protected:
   bool jobFreePhysSpans();
+  bool jobFreeCmd();
 
 private:
   // initialize our pointer to libc's pthread_create, etc.  This
@@ -120,6 +130,9 @@ private:
 
   FreeRingVector* _spansFreeBuffer{nullptr};
   FreeRingVector* _spansReturnBuffer{nullptr};
+
+  FreeCmdRingVector* _pagesFreeCmdBuffer{nullptr};
+  FreeCmdRingVector* _pagesReturnCmdBuffer{nullptr};
 };
 
 // get a reference to the Runtime singleton

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -90,8 +90,12 @@ public:
     return _pid;
   }
 
-  void sendFreeCmd(internal::FreeCmd* fComand) {
-    _pagesFreeCmdBuffer->push(fComand);
+  bool sendFreeCmd(internal::FreeCmd* fComand) {
+    return _pagesFreeCmdBuffer->try_push(fComand);
+  }
+
+  void selfFlush() {
+
   }
 
   internal::FreeCmd* getReturnCmdFromBg() {
@@ -113,8 +117,11 @@ public:
     return _flushSpans;
   }
 
+  bool freeThreadRunning() const { return _freeThreadRunning; }
+
 protected:
   bool jobFreeCmd();
+  void autoFlush();
 
 private:
   // initialize our pointer to libc's pthread_create, etc.  This
@@ -138,6 +145,7 @@ private:
   FreeCmdRingVector* _pagesFreeCmdBuffer{nullptr};
   FreeCmdRingVector* _pagesReturnCmdBuffer{nullptr};
   internal::vector<Span>  _flushSpans;
+  bool _freeThreadRunning{false};
 };
 
 // get a reference to the Runtime singleton

--- a/src/shuffle_vector.h
+++ b/src/shuffle_vector.h
@@ -69,7 +69,8 @@ public:
   }
 
   // post: list has the index of all bits set to 1 in it, in a random order
-  inline uint32_t ATTRIBUTE_ALWAYS_INLINE refillFrom(uint8_t mhOffset, internal::Bitmap &bitmap, internal::Bitmap *meshedBitmap) {
+  inline uint32_t ATTRIBUTE_ALWAYS_INLINE refillFrom(uint8_t mhOffset, internal::Bitmap &bitmap,
+                                                     internal::Bitmap *meshedBitmap) {
     d_assert(_maxCount > 0);
     d_assert_msg(_maxCount <= kMaxShuffleVectorLength, "objCount? %zu <= %zu", _maxCount, kMaxShuffleVectorLength);
 

--- a/src/shuffle_vector.h
+++ b/src/shuffle_vector.h
@@ -69,7 +69,7 @@ public:
   }
 
   // post: list has the index of all bits set to 1 in it, in a random order
-  inline uint32_t ATTRIBUTE_ALWAYS_INLINE refillFrom(uint8_t mhOffset, internal::Bitmap &bitmap) {
+  inline uint32_t ATTRIBUTE_ALWAYS_INLINE refillFrom(uint8_t mhOffset, internal::Bitmap &bitmap, internal::Bitmap *meshedBitmap) {
     d_assert(_maxCount > 0);
     d_assert_msg(_maxCount <= kMaxShuffleVectorLength, "objCount? %zu <= %zu", _maxCount, kMaxShuffleVectorLength);
 
@@ -96,6 +96,10 @@ public:
       // should fix that.
       if (i >= maxCount) {
         break;
+      }
+
+      if (unlikely(meshedBitmap)) {
+        meshedBitmap->tryToSet(i);
       }
 
       if (unlikely(isFull())) {
@@ -155,8 +159,12 @@ public:
       if (mh->isFull()) {
         continue;
       }
+      internal::Bitmap *meshed = nullptr;
+      if (unlikely(mh->hasMeshed())) {
+        meshed = &(mh->NextMeshedMiniHeap()->writableBitmap());
+      }
 
-      const auto allocCount = refillFrom(_attachedOff, mh->writableBitmap());
+      const auto allocCount = refillFrom(_attachedOff, mh->writableBitmap(), meshed);
       addedCapacity |= allocCount;
     }
 

--- a/src/testing/unit/triple_mesh_test.cc
+++ b/src/testing/unit/triple_mesh_test.cc
@@ -251,7 +251,7 @@ static void meshTestConcurrentWrite(bool invert1, bool invert2) {
 
   // we need to attach the miniheap, otherwise
   ASSERT_TRUE(!mh1->isAttached());
-  mh1->setAttached(gettid(), gheap.freelistFor(mh1->freelistId(), sizeClass));
+  mh1->setAttached(gettid(), &gheap.freelistFor(mh1->freelistId(), sizeClass)->first);
   ASSERT_TRUE(mh1->isAttached());
 
   // now free the objects by going through the global heap -- it

--- a/src/thread_local_heap.h
+++ b/src/thread_local_heap.h
@@ -195,9 +195,14 @@ public:
     size_t startEpoch{0};
     auto mh = _global->miniheapForWithEpoch(ptr, startEpoch);
     if (likely(mh && mh->current() == _current && !mh->hasMeshed())) {
-      ShuffleVector &shuffleVector = _shuffleVector[mh->sizeClass()];
-      shuffleVector.free(mh, ptr);
-      return;
+      if (!mh->hasMeshed()) {
+        ShuffleVector &shuffleVector = _shuffleVector[mh->sizeClass()];
+        shuffleVector.free(mh, ptr);
+        return;
+      } else {
+        mh->free(_global->arenaBegin(), ptr);
+        return;
+      }
     }
 
     _global->freeFor(mh, ptr, startEpoch);


### PR DESCRIPTION
I found the madvise system call is too many

kyo@kyo-1080:~/work/mimalloc/test$ LD_PRELOAD=~/work/Mesh/build/lib/libmesh.so strace -c ./test-stress
Using 32 threads with a 10% load-per-thread and 50 iterations
- iterations left:  40
- iterations left:  30
- iterations left:  20
- iterations left:  10
- iterations left:   0
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 78.98    8.638044      146407        59         2 futex
 10.14    1.109295           3    314424           madvise
  9.49    1.037568           4    250535           fallocate
  0.48    0.052226           4     12631           mmap
  0.44    0.048603          30      1600           clone
  0.39    0.042324           3     13116           mprotect
  0.07    0.007847           5      1401           munmap
  0.00    0.000290         290         1           execve
  0.00    0.000085           4        21        12 openat
  0.00    0.000033           5         6           write
  0.00    0.000027           3         8           read
  0.00    0.000023           2         8         7 stat
  0.00    0.000022           2         8           pread64
  0.00    0.000019           2         8           close
  0.00    0.000018           2         8           fstat
  0.00    0.000009           2         4           rt_sigaction
  0.00    0.000005           2         2           rt_sigprocmask
  0.00    0.000005           2         2         1 arch_prctl
  0.00    0.000005           2         2           gettid
  0.00    0.000004           4         1         1 access
  0.00    0.000004           4         1           signalfd4
  0.00    0.000004           4         1           memfd_create
  0.00    0.000003           3         1           brk
  0.00    0.000003           3         1           ftruncate
  0.00    0.000003           3         1           set_tid_address
  0.00    0.000003           3         1           prlimit64
  0.00    0.000002           2         1           getpid
  0.00    0.000002           2         1           set_robust_list
------ ----------- ----------- --------- --------- ----------------
100.00   10.936476                593853        23 total

real    0m8.902s
user    0m9.365s
sys     0m10.089s

And I found we can combine some madvise together, after optimized,

kyo@kyo-1080:~/work/mimalloc/test$ LD_PRELOAD=~/work/Mesh/build/lib/libmesh.so strace -c ./test-stress
Using 32 threads with a 10% load-per-thread and 50 iterations
- iterations left:  40
- iterations left:  30
- iterations left:  20
- iterations left:  10
- iterations left:   0
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 76.84    7.600092      124591        61         2 futex
 13.88    1.372967           5    247169           fallocate
  7.66    0.757321           3    242003           madvise
  0.56    0.055819          34      1600           clone
  0.49    0.048204           4     11942           mprotect
  0.48    0.047123           4     11166           mmap
  0.08    0.008145           5      1401           munmap
  0.00    0.000281         281         1           execve
  0.00    0.000088           4        21        12 openat
  0.00    0.000040           6         6           write
  0.00    0.000030           3         8           read
  0.00    0.000022           2         8           close
  0.00    0.000022           2         8           pread64
  0.00    0.000021           2         8         7 stat
  0.00    0.000021           2         8           fstat
  0.00    0.000010           2         4           rt_sigaction
  0.00    0.000006           3         2           rt_sigprocmask
  0.00    0.000006           3         2         1 arch_prctl
  0.00    0.000005           5         1         1 access
  0.00    0.000005           2         2           gettid
  0.00    0.000004           4         1           signalfd4
  0.00    0.000004           4         1           memfd_create
  0.00    0.000003           3         1           brk
  0.00    0.000003           3         1           getpid
  0.00    0.000003           3         1           ftruncate
  0.00    0.000003           3         1           set_tid_address
  0.00    0.000002           2         1           set_robust_list
  0.00    0.000002           2         1           prlimit64
------ ----------- ----------- --------- --------- ----------------
100.00    9.890252                515429        23 total

real    0m8.202s
user    0m9.259s
sys     0m9.068s

It's much more faster now. And use the gcore to test the dump size, now mesh is already smaller than the Glibc. So there is no reason not to use kAdviseDump.