### PR TITLE
Bump the version of GoogleTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ include(ExternalProject)
 
 ExternalProject_Add(googletest
         GIT_REPOSITORY    https://github.com/google/googletest.git
-        GIT_TAG           703bd9caab50b139428cea1aaff9974ebee5742e
+        GIT_TAG           3e0e32ba300ce8afe695ad3ba7e81b21b7cf237a
         SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
         BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
         INSTALL_COMMAND   ""


### PR DESCRIPTION
This is apparently blocking https://github.com/daanx/mimalloc-bench/pull/47 because fedora is annoying about `-Werror`, and the issue was [fixed last year]( https://github.com/google/googletest/commit/4679637f1c9d5a0728bdc347a531737fad0b1ca3#diff-97f768d897442b94f24002f6bcff7124e3c73d05b3916fb492ee29436ce0701f )