### PR TITLE
Make tests optional & use submodule for Heap-Layers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "external/Heap-Layers"]
+	path = external/Heap-Layers
+	url = https://github.com/emeryberger/Heap-Layers.git
+[submodule "external/googletest"]
+	path = external/googletest
+	url = https://github.com/google/googletest.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,32 +12,10 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_OUTPUT_DIRECTORY}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_OUTPUT_DIRECTORY}/lib)
 set(CMAKE_HEADER_OUTPUT_DIRECTORY  ${CMAKE_OUTPUT_DIRECTORY}/include)
 
-
-include(ExternalProject)
-
-ExternalProject_Add(googletest
-        GIT_REPOSITORY    https://github.com/google/googletest.git
-        GIT_TAG           3e0e32ba300ce8afe695ad3ba7e81b21b7cf237a
-        SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
-        BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
-        INSTALL_COMMAND   ""
-        TEST_COMMAND      ""
-)
-
-ExternalProject_Add(heap_layers
-        GIT_REPOSITORY    https://github.com/emeryberger/Heap-Layers.git
-        GIT_TAG           a80041cc15174ab82a39bae1cd750b52955c7eef
-        SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/heap_layers-src"
-        BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/heap_layers-build"
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND     ""
-        INSTALL_COMMAND   ""
-        TEST_COMMAND      ""
-)
-
 #Create configure options
 option(DEBUG "Build with debugging symbols" OFF) #replace with CMAKE_BUILD_TYPE?
-option(OPTIMIZE " Build with optimizations" ON) #replace with CMAKE_BUILD_TYPE?
+option(OPTIMIZE "Build with optimizations" ON) #replace with CMAKE_BUILD_TYPE?
+option(BUILD_TESTS "Build with tests" OFF)
 option(GCOV "Build with gcov profiling support" OFF)
 option(CLANGCOV "Build with clangcov profiling support" OFF)
 set(RANDOMIZATION "1" CACHE STRING "0: no randomization. 1: freelist init only.  2: freelist init + free fastpath")
@@ -102,6 +80,7 @@ else()
 endif()
 
 if (${GCOV} AND GCC)
+    set(BUILD_TESTS ON)
     find_program(GCOVp gcov)
     if (GCOVp)
         add_definitions(--coverage)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,6 @@
 #Include current folder to guarantee headers are found by files
 include_directories(./)
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/../heap_layers-src)
-# include_directories(./vendor/Heap-Layers)
+include_directories(${CMAKE_SOURCE_DIR}/external/Heap-Layers)
 
 #Create a common set of source files
 set(common_src
@@ -23,6 +22,9 @@ set(mesh_src
 add_library(mesh SHARED ${mesh_src})
 target_link_libraries(mesh PRIVATE -pthread -ldl)
 
+if(${BUILD_TESTS})
+find_package(GTest 1.0 REQUIRED)
+
 #Create a set of source files for the unit tests
 set(unit_src
         ${common_src}
@@ -39,17 +41,12 @@ set(unit_src
 add_executable(unit.test ${unit_src})
 target_link_libraries(unit.test PRIVATE -ldl -pthread )
 
-set(GTEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/../googletest-src/googletest)
+target_link_libraries(unit.test PRIVATE GTest::GTest)
 
-ExternalProject_Get_Property(googletest binary_dir)
-set(GTEST_LIBRARY_PATH ${binary_dir}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}gtest.a)
-target_link_libraries(unit.test PRIVATE ${GTEST_LIBRARY_PATH})
-
-set(GTEST_MAIN_LIBRARY_PATH ${binary_dir}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}gtest_main.a)
-target_link_libraries(unit.test PRIVATE ${GTEST_MAIN_LIBRARY_PATH})
+target_link_libraries(unit.test PRIVATE GTest::Main)
 
 #Include header file paths to the unit tests
-target_include_directories(unit.test SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../googletest-src/googletest/include)
+target_include_directories(unit.test SYSTEM PRIVATE ${CMAKE_SOURCE_DIR}/external/googletest/include)
 
 #Set specific compiler flags for the unit tests
 target_compile_definitions(unit.test PRIVATE -DGTEST_HAS_PTHREAD=1)
@@ -82,4 +79,5 @@ if(${CLANGCOV})
     #        COMMAND rm -f default.profraw
     #        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/coverage/
     #        DEPENDS unit.test)
+endif()
 endif()


### PR DESCRIPTION
I'm currently checking if Mesh can be built for embedded devices in yocto. For this to work, cmake should depend on a pre-installed google test.

I also added the Heap-Layers repository as submodule, which makes it easier to include in cmake as well.

Finally, I added an option to enable/disable tests. I disabled them by default as I think that most users want to use the library and not test it.