### PR TITLE
cmake: using CMAKE_BUILD_TYPE instead of custom vars.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,6 @@ ExternalProject_Add(heap_layers
 )
 
 #Create configure options
-option(DEBUG "Build with debugging symbols" OFF) #replace with CMAKE_BUILD_TYPE?
-option(OPTIMIZE " Build with optimizations" ON) #replace with CMAKE_BUILD_TYPE?
 option(GCOV "Build with gcov profiling support" OFF)
 option(CLANGCOV "Build with clangcov profiling support" OFF)
 set(RANDOMIZATION "1" CACHE STRING "0: no randomization. 1: freelist init only.  2: freelist init + free fastpath")
@@ -91,14 +89,8 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel")
     set(ICC TRUE)
 endif()
 
-if (${DEBUG})
-    add_definitions(-g)
-endif()
-
-if(${OPTIMIZE})
-    add_definitions(-O3 -flto -D_FORTIFY_SOURCE=2)
-else()
-    add_definitions(-O0)
+if (NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
 endif()
 
 if (${GCOV} AND GCC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,14 @@ set(mesh_src
 #Add a target for the mesh shared library
 add_library(mesh SHARED ${mesh_src})
 target_link_libraries(mesh PRIVATE -pthread -ldl)
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  include(CheckIPOSupported)
+  check_ipo_supported(RESULT HAS_IPO)
+  if(${HAS_IPO})
+    set_property(TARGET mesh PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+  endif()
+  target_compile_definitions(mesh PRIVATE -D_FORTIFY_SOURCE=2)
+endif()
 
 #Create a set of source files for the unit tests
 set(unit_src


### PR DESCRIPTION
for optimized build, checking first proper lto support which cmake will apply proper flag whether it is clang or gcc.