### PR TITLE
Fix definition of MiniHeap::bytesFree

### DIFF
--- a/src/mini_heap.h
+++ b/src/mini_heap.h
@@ -281,7 +281,7 @@ public:
   }
 
   inline size_t bytesFree() const {
-    return inUseCount() * objectSize();
+    return (maxCount() - inUseCount()) * objectSize();
   }
 
   inline void setMeshed() {


### PR DESCRIPTION
Previously `MiniHeap::bytesFree` was reporting the bytes allocated, not the bytes free. This was impacting `GlobalHeap::allocSmallMiniheaps` which was always seeing `bytesFree()` return 0, and thus was always allocating the maximum number of MiniHeaps instead of stopping at `bytesFree >= kMiniheapRefillGoalSize`