### PR TITLE
common: define kMiniHeapSize and use it in MeshableArena's CheapHeap

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -69,6 +69,11 @@ static constexpr int kMapShared = 1;
 static constexpr int kMapShared = kMeshingEnabled ? MAP_SHARED : MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE;
 #endif
 
+// we have to define this here for use in meshable_arena's CheapHeap we allocate
+// MiniHeaps out of.  We validate (and fail compilation) if this gets out of date
+// with a static_assert at the bottom of mini_heap.h
+static constexpr size_t kMiniHeapSize = 64;
+
 static constexpr size_t kMinObjectSize = 16;
 static constexpr size_t kMaxSize = 16384;
 static constexpr size_t kClassSizesMax = 25;

--- a/src/meshable_arena.h
+++ b/src/meshable_arena.h
@@ -277,7 +277,7 @@ private:
   atomic<MiniHeapID> *_mhIndex{nullptr};
 
 protected:
-  CheapHeap<64, kArenaSize / kPageSize> _mhAllocator{};
+  CheapHeap<kMiniHeapSize, kArenaSize / kPageSize> _mhAllocator{};
   MWC _fastPrng;
 
 private:

--- a/src/mini_heap.h
+++ b/src/mini_heap.h
@@ -526,6 +526,7 @@ typedef FixedArray<MiniHeap, 63> MiniHeapArray;
 static_assert(sizeof(pid_t) == 4, "pid_t not 32-bits!");
 static_assert(sizeof(mesh::internal::Bitmap) == 32, "Bitmap too big!");
 static_assert(sizeof(MiniHeap) == 64, "MiniHeap too big!");
+static_assert(sizeof(MiniHeap) == kMiniHeapSize, "MiniHeap size mismatch");
 static_assert(sizeof(MiniHeapArray) == 64 * sizeof(void *), "MiniHeapArray too big!");
 }  // namespace mesh
 


### PR DESCRIPTION
It was surprising and frustrating to find a random `64` in `MeshableArena`'s:
```c++
  CheapHeap<64, kArenaSize / kPageSize> _mhAllocator{};
```

is tied to the size of `MiniHeap`.  Make that explicit by defining a constant, and ensuring the constant stays in line with the size of `MiniHeap` through the use of a `static_assert`.

Updates #104