### PR TITLE
re-enable meshing regression tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: build in debug mode
         run: |
-          ./bazel test -c dbg //src:unit-tests --cxxopt=-DCI_DEBUG_MESH=1
+          ./bazel test -c dbg //src:unit-tests --copt=-DCI_DEBUG_MESH=1
       - name: build tests and binary
         run: |
           make -j1
@@ -52,7 +52,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: build in debug mode
       run: |
-        ./bazel test -c dbg //src:unit-tests --test_output=all --cxxopt=-DCI_DEBUG_MESH=1
+        ./bazel test -c dbg //src:unit-tests --test_output=all --copt=-DCI_DEBUG_MESH=1
     - name: build tests and binary
       run: |
         make -j1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: build in debug mode
         run: |
-          ./bazel test -c dbg //src:unit-tests --copt=-DCI_DEBUG_MESH=1
+          ./bazel test -c dbg //src:unit-tests --copt=-DCI_DEBUG_MESH=1 --host_copt=-DCI_DEBUG_MESH=1 --test_env=CI_DEBUG_MESH=1
       - name: build tests and binary
         run: |
           make -j1
@@ -52,7 +52,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: build in debug mode
       run: |
-        ./bazel test -c dbg //src:unit-tests --test_output=all --copt=-DCI_DEBUG_MESH=1
+        ./bazel test -c dbg //src:unit-tests --test_output=all --copt=-DCI_DEBUG_MESH=1 --host_copt=-DCI_DEBUG_MESH=1 --test_env=CI_DEBUG_MESH=1
     - name: build tests and binary
       run: |
         make -j1

--- a/src/BUILD
+++ b/src/BUILD
@@ -202,6 +202,7 @@ cc_test(
     copts = [
         "-Isrc",
     ] + MESH_DEFAULT_COPTS,
+    defines = COMMON_DEFINES,  # Include common defines for consistent behavior
     linkopts = COMMON_LINKOPTS,
     deps = [
         ":mesh-core",

--- a/src/global_heap.h
+++ b/src/global_heap.h
@@ -119,6 +119,13 @@ public:
     d_assert(spanBegin != nullptr);
     d_assert((reinterpret_cast<uintptr_t>(spanBegin) / getPageSize()) % pageAlignment == 0);
 
+#ifdef CI_DEBUG_MESH
+    fprintf(stderr, "[CI_DEBUG_MESH] allocMiniheapLocked: Allocated span for sizeClass=%d, pageCount=%zu, objectSize=%zu\n",
+            sizeClass, pageCount, objectSize);
+    fprintf(stderr, "[CI_DEBUG_MESH]   span: offset=%u, length=%zu bytes, spanBegin=%p\n",
+            span.offset, span.byteLength(), static_cast<void*>(spanBegin));
+#endif
+
     MiniHeapT *mh = new (buf) MiniHeapT(arenaBegin(), span, objectCount, objectSize);
 
     const auto miniheapID = MiniHeapID{_mhAllocator.offsetFor(buf)};

--- a/src/memory_stats.h
+++ b/src/memory_stats.h
@@ -7,6 +7,7 @@
 #ifndef MESH__MEMORY_STATS_H
 #define MESH__MEMORY_STATS_H
 
+#include <cstddef>
 #include <cstdint>
 
 namespace mesh {
@@ -27,6 +28,12 @@ struct MemoryStats {
   // Get current memory statistics for this process.
   // Returns true on success, false on failure.
   static bool get(MemoryStats& stats);
+
+  // Best-effort resident byte count for a specific virtual address range.
+  // - Linux: parsed from /proc/self/smaps (Rss field)
+  // - macOS: falls back to mesh_memory_bytes (process RSS) as a coarse proxy
+  // Returns true on success, false on failure.
+  static bool regionResidentBytes(const void* region_begin, size_t region_size, uint64_t& bytes_out);
 };
 
 }  // namespace mesh

--- a/src/memory_stats_macos.cc
+++ b/src/memory_stats_macos.cc
@@ -80,6 +80,17 @@ bool MemoryStats::get(MemoryStats& stats) {
   return true;
 }
 
+bool MemoryStats::regionResidentBytes(const void* /*region_begin*/, size_t /*region_size*/, uint64_t& bytes_out) {
+  MemoryStats stats;
+  if (!MemoryStats::get(stats)) {
+    return false;
+  }
+  // Coarse approximation: use process-level RSS on macOS where the arena is
+  // accounted in RSS.
+  bytes_out = stats.mesh_memory_bytes;
+  return true;
+}
+
 }  // namespace mesh
 
 #endif  // __APPLE__

--- a/src/meshable_arena.cc
+++ b/src/meshable_arena.cc
@@ -399,7 +399,15 @@ void MeshableArena::partialScavenge() {
 void MeshableArena::scavenge(bool force) {
   const size_t minDirtyPageThreshold = (kMinDirtyPageThreshold * kPageSizeMin) / getPageSize();
 
+#ifdef CI_DEBUG_MESH
+  fprintf(stderr, "[CI_DEBUG_MESH] scavenge called: force=%s, dirtyPageCount=%zu, threshold=%zu\n",
+          force ? "true" : "false", _dirtyPageCount, minDirtyPageThreshold);
+#endif
+
   if (!force && _dirtyPageCount < minDirtyPageThreshold) {
+#ifdef CI_DEBUG_MESH
+    fprintf(stderr, "[CI_DEBUG_MESH] scavenge: Skipping (dirty pages below threshold)\n");
+#endif
     return;
   }
 
@@ -491,6 +499,17 @@ void MeshableArena::scavenge(bool force) {
       hard_assert(false);
     }
   }
+#endif
+
+#ifdef CI_DEBUG_MESH
+  size_t cleanPageCount = 0;
+  for (size_t i = 0; i < kSpanClassCount; i++) {
+    for (const auto& span : _clean[i]) {
+      cleanPageCount += span.length;
+    }
+  }
+  fprintf(stderr, "[CI_DEBUG_MESH] scavenge: Completed. Clean pages: %zu, Meshed pages: %zu\n",
+          cleanPageCount, _meshedPageCount);
 #endif
 }
 

--- a/src/testing/unit/mesh_memory_test.cc
+++ b/src/testing/unit/mesh_memory_test.cc
@@ -154,6 +154,14 @@ void testPrecisePageDeallocation() {
       printf("Continuing test anyway...\n\n");
       // Don't skip - let's see if the test can still work
     }
+
+    // Force scavenge to clean up the test allocation before continuing
+    gheap.scavenge(true);
+
+    // Take a fresh baseline AFTER cleanup for accurate Phase 1 measurements
+    ASSERT_TRUE(MemoryStats::get(baseline));
+    printf("Post-cleanup baseline RSS: %" PRIu64 " bytes, Mesh memory: %" PRIu64 " bytes\n\n",
+           baseline.resident_size_bytes, baseline.mesh_memory_bytes);
   }
 #endif
 


### PR DESCRIPTION
The MeshMemory.PrecisePageDeallocation test is being skipped in CI with the assumption that RssShmem tracking isn't working, but this hypothesis was never actually verified. This commit adds detailed logging to help determine the actual root cause.

Added logging to:
1. Linux memory stats parsing (memory_stats_linux.cc):
   - Shows whether /proc/self/status can be read
   - Logs presence/absence of VmRSS and RssShmem fields
   - Reports actual parsed values

2. Test's RssShmem detection section (mesh_memory_test.cc):
   - Baseline memory stats before allocation
   - MiniHeap allocation details
   - Memory stats after allocation
   - Clear hypothesis checking with 3 possible scenarios

3. Memory allocation tracking (global_heap.h):
   - Logs when MiniHeaps are allocated
   - Shows span details (offset, length, pointer)

4. Scavenge operations (meshable_arena.cc):
   - When scavenge is called and why
   - Final results (clean pages, meshed pages)

This logging is controlled by the CI_DEBUG_MESH flag already set in CI, so once pushed, we'll get detailed diagnostics to confirm or reject the RssShmem hypothesis and understand the actual issue.