### PR TITLE
perf: lock-free freelist queuing, sharding global lock, reduce contention in getPageSize()

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,9 @@ jobs:
       - name: build tests and binary
         run: |
           make -j1
+      - name: run benchmark (catches IFUNC static linking issues)
+        run: |
+          make benchmark
 
   macOS_bazel:
     runs-on: macos-latest
@@ -52,6 +55,9 @@ jobs:
     - name: build tests and binary
       run: |
         make -j1
+    - name: run benchmark
+      run: |
+        make benchmark
 
   #Windows_MinGW:   
   #

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ TAGS
 /src/test/fork-example
 /src/test/thread-example
 /unit.test
+/*.old
 /meshing-benchmark
 config.mk
 /build

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ larson-mesh:
 larson-nomesh:
 	./bazel build $(BAZEL_CONFIG) --config=disable-meshing --config=nolto -c opt //src:larson-benchmark
 ifeq ($(UNAME_S),Linux)
-	perf record -F $(PERF_FREQ) -g --call-graph dwarf -o perf-larson-nomesh.data -- ./bazel-bin/src/larson-benchmark $(LARSON_ARGS)
+	perf record -F $(PERF_FREQ) -g --call-graph fp -o perf-larson-nomesh.data -- ./bazel-bin/src/larson-benchmark $(LARSON_ARGS)
 	perf script -i perf-larson-nomesh.data | $(FLAMEGRAPH_DIR)/stackcollapse-perf.pl | $(FLAMEGRAPH_DIR)/flamegraph.pl --title "larson-nomesh" > flamegraph-larson-nomesh.svg
 	@echo "Flamegraph written to flamegraph-larson-nomesh.svg"
 else

--- a/src/common.h
+++ b/src/common.h
@@ -111,8 +111,15 @@ inline constexpr size_t getPageSize() {
   return kPageSize16K;
 }
 static_assert(getPageSize() == kPageSize16K, "Apple Silicon uses 16KB pages");
+#elif defined(__x86_64__)
+// x86_64 always uses 4KB pages; make this a compile-time constant so
+// the compiler can fold away any page-size conditionals.
+inline constexpr size_t getPageSize() {
+  return kPageSize4K;
+}
+static_assert(getPageSize() == kPageSize4K, "x86_64 uses 4KB pages");
 #else
-// Runtime page size - initialized on first access
+// Runtime page size - initialized on first access (ARM64 Linux can have 4KB or 16KB)
 inline size_t getPageSize() {
   static const size_t kPageSize = internal::initPageSize();
   return kPageSize;

--- a/src/global_heap_impl.h
+++ b/src/global_heap_impl.h
@@ -99,9 +99,9 @@ void GlobalHeap<PageSize>::freeFor(MiniHeapT *mh, void *ptr, size_t startEpoch) 
   // This can also include, for example, single page allocations w/
   // 16KB alignment.
   if (mh->isLargeAlloc()) {
-    // Lock ordering: arena lock first, then large alloc lock
-    lock_guard<mutex> arenaLock(_arenaLock);
+    // Lock ordering: large alloc lock -> arena lock
     lock_guard<mutex> lock(_largeAllocLock);
+    lock_guard<mutex> arenaLock(_arenaLock);
     freeMiniheapLocked(mh, false);
     return;
   }

--- a/src/ifunc_resolver.h
+++ b/src/ifunc_resolver.h
@@ -1,0 +1,215 @@
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil -*-
+// Copyright 2024 The Mesh Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+#ifndef MESH__IFUNC_RESOLVER_H
+#define MESH__IFUNC_RESOLVER_H
+
+#include "common.h"
+
+#ifdef __linux__
+#include <elf.h>
+#include <fcntl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+// ===================================================================
+// IFUNC Resolver Infrastructure
+// ===================================================================
+//
+// This header provides utilities for IFUNC (Indirect Function) resolvers.
+// IFUNC resolvers execute during dynamic linking BEFORE any of the following
+// are available:
+//   - glibc initialization (no malloc, no stdio, no getauxval)
+//   - libstdc++ availability (no C++ standard library)
+//   - TLS (Thread-Local Storage) setup
+//   - Most syscall wrappers (syscall() function not available)
+//   - Any library functions whatsoever
+//
+// The resolver runs in an extremely restricted environment where we MUST:
+//   - Parse auxv (auxiliary vector) directly from /proc/self/auxv
+//   - Use ONLY raw syscalls via inline assembly (no libc wrappers)
+//   - Avoid ALL library function calls
+//   - Keep logic minimal and completely self-contained
+//   - Not use any global variables (they may not be initialized)
+//
+// This is why we need raw inline assembly for syscalls and manual parsing
+// of the auxiliary vector.
+// ===================================================================
+
+namespace mesh {
+namespace ifunc {
+
+#ifdef __aarch64__
+// ===================================================================
+// ARM64 Syscall Implementation
+// ===================================================================
+// ARM64 inline assembly for system calls - REQUIRED because syscall()
+// wrapper is not available during IFUNC resolution.
+//
+// ARM64 calling convention for syscalls:
+//   - Syscall number goes in x8 register
+//   - Arguments go in x0-x5 registers
+//   - Return value comes back in x0
+//   - SVC #0 instruction triggers the syscall
+// ===================================================================
+
+__attribute__((no_stack_protector)) inline long syscall_3(long nr, long arg0, long arg1, long arg2) {
+  register long x8 __asm__("x8") = nr;
+  register long x0 __asm__("x0") = arg0;
+  register long x1 __asm__("x1") = arg1;
+  register long x2 __asm__("x2") = arg2;
+  __asm__ volatile("svc #0" : "+r"(x0) : "r"(x8), "r"(x1), "r"(x2) : "memory", "cc");
+  return x0;
+}
+
+__attribute__((no_stack_protector)) inline long syscall_1(long nr, long arg0) {
+  register long x8 __asm__("x8") = nr;
+  register long x0 __asm__("x0") = arg0;
+  __asm__ volatile("svc #0" : "+r"(x0) : "r"(x8) : "memory", "cc");
+  return x0;
+}
+
+__attribute__((no_stack_protector)) inline int sys_open(const char *pathname, int flags) {
+  return syscall_3(SYS_openat, -100 /* AT_FDCWD */, (long)pathname, flags);
+}
+
+__attribute__((no_stack_protector)) inline ssize_t sys_read(int fd, void *buf, size_t count) {
+  return syscall_3(SYS_read, fd, (long)buf, count);
+}
+
+__attribute__((no_stack_protector)) inline int sys_close(int fd) {
+  return syscall_1(SYS_close, fd);
+}
+
+#elif defined(__x86_64__)
+// ===================================================================
+// x86_64 Syscall Implementation
+// ===================================================================
+// x86_64 inline assembly for system calls - REQUIRED because syscall()
+// wrapper is not available during IFUNC resolution.
+//
+// x86_64 calling convention for syscalls:
+//   - Syscall number goes in rax register
+//   - Arguments go in rdi, rsi, rdx, r10, r8, r9 registers (in order)
+//   - Return value comes back in rax
+//   - SYSCALL instruction triggers the syscall
+//   - rcx and r11 are clobbered by SYSCALL instruction
+// ===================================================================
+
+__attribute__((no_stack_protector)) inline long syscall_3(long nr, long arg0, long arg1, long arg2) {
+  long ret;
+  __asm__ volatile("syscall" : "=a"(ret) : "a"(nr), "D"(arg0), "S"(arg1), "d"(arg2) : "rcx", "r11", "memory", "cc");
+  return ret;
+}
+
+__attribute__((no_stack_protector)) inline long syscall_4(long nr, long arg0, long arg1, long arg2, long arg3) {
+  long ret;
+  register long r10 __asm__("r10") = arg3;
+  __asm__ volatile("syscall" : "=a"(ret) : "a"(nr), "D"(arg0), "S"(arg1), "d"(arg2), "r"(r10) : "rcx", "r11", "memory",
+                   "cc");
+  return ret;
+}
+
+__attribute__((no_stack_protector)) inline long syscall_1(long nr, long arg0) {
+  long ret;
+  __asm__ volatile("syscall" : "=a"(ret) : "a"(nr), "D"(arg0) : "rcx", "r11", "memory", "cc");
+  return ret;
+}
+
+__attribute__((no_stack_protector)) inline int sys_open(const char *pathname, int flags) {
+  return syscall_4(SYS_openat, -100 /* AT_FDCWD */, (long)pathname, flags, 0);
+}
+
+__attribute__((no_stack_protector)) inline ssize_t sys_read(int fd, void *buf, size_t count) {
+  return syscall_3(SYS_read, fd, (long)buf, count);
+}
+
+__attribute__((no_stack_protector)) inline int sys_close(int fd) {
+  return syscall_1(SYS_close, fd);
+}
+
+#endif  // __x86_64__
+
+#if defined(__aarch64__) || defined(__x86_64__)
+// ===================================================================
+// Page Size Detection via Auxiliary Vector
+// ===================================================================
+// This function reads the page size from the kernel's auxiliary vector
+// by directly parsing /proc/self/auxv. We CANNOT use getauxval(AT_PAGESZ)
+// because:
+//   1. getauxval() is part of glibc which isn't initialized yet
+//   2. We're running in the IFUNC resolver context before libraries load
+//
+// The auxiliary vector is a set of key-value pairs passed by the kernel
+// to each process at startup, containing information like page size,
+// clock tick rate, etc. AT_PAGESZ (type 6) contains the system page size.
+//
+// Fallback values:
+//   - ARM64: 16KB (common on newer ARM64 systems, safe for 4KB systems)
+//   - x86_64: 4KB (standard and only option on x86_64)
+// ===================================================================
+__attribute__((no_stack_protector)) inline size_t getPageSizeFromAuxv() {
+  // Use stack buffer to avoid any heap allocation (malloc not available)
+  unsigned char buffer[512];
+  int fd = sys_open("/proc/self/auxv", O_RDONLY);
+
+  if (fd < 0) {
+#ifdef __aarch64__
+    return kPageSize16K;
+#else
+    return kPageSize4K;
+#endif
+  }
+
+  ssize_t bytes_read = sys_read(fd, buffer, sizeof(buffer));
+  sys_close(fd);
+
+  if (bytes_read < (ssize_t)sizeof(Elf64_auxv_t)) {
+#ifdef __aarch64__
+    return kPageSize16K;
+#else
+    return kPageSize4K;
+#endif
+  }
+
+  // Parse the auxiliary vector
+  Elf64_auxv_t *auxv = (Elf64_auxv_t *)buffer;
+  Elf64_auxv_t *auxv_end = (Elf64_auxv_t *)(buffer + bytes_read);
+
+  while (auxv < auxv_end && auxv->a_type != AT_NULL) {
+    if (auxv->a_type == AT_PAGESZ) {
+      size_t pagesize = auxv->a_un.a_val;
+      // Sanity check: we ONLY support 4KB and 16KB page sizes
+      if (pagesize == kPageSize4K || pagesize == kPageSize16K) {
+        return pagesize;
+      }
+#ifdef __aarch64__
+      return kPageSize16K;
+#else
+      return kPageSize4K;
+#endif
+    }
+    auxv++;
+  }
+
+#ifdef __aarch64__
+  return kPageSize16K;
+#else
+  return kPageSize4K;
+#endif
+}
+#else
+// For unsupported architectures, fall back to 4KB
+inline size_t getPageSizeFromAuxv() {
+  return kPageSize4K;
+}
+#endif  // defined(__aarch64__) || defined(__x86_64__)
+
+}  // namespace ifunc
+}  // namespace mesh
+
+#endif  // __linux__
+
+#endif  // MESH__IFUNC_RESOLVER_H

--- a/src/ifunc_resolver.h
+++ b/src/ifunc_resolver.h
@@ -107,8 +107,10 @@ __attribute__((no_stack_protector)) inline long syscall_3(long nr, long arg0, lo
 __attribute__((no_stack_protector)) inline long syscall_4(long nr, long arg0, long arg1, long arg2, long arg3) {
   long ret;
   register long r10 __asm__("r10") = arg3;
-  __asm__ volatile("syscall" : "=a"(ret) : "a"(nr), "D"(arg0), "S"(arg1), "d"(arg2), "r"(r10) : "rcx", "r11", "memory",
-                   "cc");
+  __asm__ volatile("syscall"
+                   : "=a"(ret)
+                   : "a"(nr), "D"(arg0), "S"(arg1), "d"(arg2), "r"(r10)
+                   : "rcx", "r11", "memory", "cc");
   return ret;
 }
 

--- a/src/libmesh.cc
+++ b/src/libmesh.cc
@@ -7,247 +7,16 @@
 
 #ifdef __linux__
 #include <sys/auxv.h>
-#include <elf.h>
 #include <unistd.h>
-#include <stdio.h>  // For debug fprintf
 #endif
 
 #include "runtime.h"
 #include "thread_local_heap.h"
 #include "runtime_impl.h"
 #include "dispatch_utils.h"
+#include "ifunc_resolver.h"
 
 using namespace mesh;
-
-#ifdef __linux__
-// ===================================================================
-// CRITICAL: IFUNC Resolver Constraints and Implementation
-// ===================================================================
-//
-// IFUNC (Indirect Function) resolvers execute during dynamic linking
-// BEFORE any of the following are available:
-//   - glibc initialization (no malloc, no stdio, no getauxval)
-//   - libstdc++ availability (no C++ standard library)
-//   - TLS (Thread-Local Storage) setup
-//   - Most syscall wrappers (syscall() function not available)
-//   - Any library functions whatsoever
-//
-// The resolver runs in an extremely restricted environment where we
-// MUST:
-//   - Parse auxv (auxiliary vector) directly from /proc/self/auxv
-//   - Use ONLY raw syscalls via inline assembly (no libc wrappers)
-//   - Avoid ALL library function calls
-//   - Keep logic minimal and completely self-contained
-//   - Not use any global variables (they may not be initialized)
-//
-// This is why we have what appears to be "complex" code below:
-//   - Raw inline assembly for syscalls (ifunc_syscall_*)
-//   - Manual parsing of auxiliary vector without getauxval()
-//   - Direct file I/O using syscalls instead of open/read/close
-//   - Conservative fallback values for error cases
-//
-// The page size detection is critical for ARM64/Apple Silicon support
-// where pages can be 4KB, 16KB, or even 64KB depending on the system.
-// ===================================================================
-
-// Direct auxiliary vector access for IFUNC resolvers
-// Uses /proc/self/auxv with inline assembly syscalls to avoid libc dependencies
-#include <sys/syscall.h>
-#include <fcntl.h>
-
-#ifdef __aarch64__
-// ===================================================================
-// ARM64 Syscall Implementation
-// ===================================================================
-// ARM64 inline assembly for system calls - REQUIRED because syscall()
-// wrapper is not available during IFUNC resolution.
-//
-// ARM64 calling convention for syscalls:
-//   - Syscall number goes in x8 register
-//   - Arguments go in x0-x5 registers
-//   - Return value comes back in x0
-//   - SVC #0 instruction triggers the syscall
-//
-// We cannot use the glibc syscall() wrapper because glibc isn't
-// initialized yet when IFUNC resolvers run.
-// ===================================================================
-
-__attribute__((no_stack_protector)) static long ifunc_syscall_3(long nr, long arg0, long arg1, long arg2) {
-  register long x8 __asm__("x8") = nr;
-  register long x0 __asm__("x0") = arg0;
-  register long x1 __asm__("x1") = arg1;
-  register long x2 __asm__("x2") = arg2;
-  __asm__ volatile("svc #0" : "+r"(x0) : "r"(x8), "r"(x1), "r"(x2) : "memory", "cc");
-  return x0;
-}
-
-__attribute__((no_stack_protector)) static long ifunc_syscall_1(long nr, long arg0) {
-  register long x8 __asm__("x8") = nr;
-  register long x0 __asm__("x0") = arg0;
-  __asm__ volatile("svc #0" : "+r"(x0) : "r"(x8) : "memory", "cc");
-  return x0;
-}
-
-// Direct syscall wrappers using inline assembly
-__attribute__((no_stack_protector)) static int ifunc_sys_open(const char *pathname, int flags) {
-  // Use openat with AT_FDCWD (-100) to open relative to current directory
-  return ifunc_syscall_3(SYS_openat, -100 /* AT_FDCWD */, (long)pathname, flags);
-}
-
-__attribute__((no_stack_protector)) static ssize_t ifunc_sys_read(int fd, void *buf, size_t count) {
-  return ifunc_syscall_3(SYS_read, fd, (long)buf, count);
-}
-
-__attribute__((no_stack_protector)) static int ifunc_sys_close(int fd) {
-  return ifunc_syscall_1(SYS_close, fd);
-}
-
-#elif defined(__x86_64__)
-// ===================================================================
-// x86_64 Syscall Implementation
-// ===================================================================
-// x86_64 inline assembly for system calls - REQUIRED because syscall()
-// wrapper is not available during IFUNC resolution.
-//
-// x86_64 calling convention for syscalls:
-//   - Syscall number goes in rax register
-//   - Arguments go in rdi, rsi, rdx, r10, r8, r9 registers (in order)
-//   - Return value comes back in rax
-//   - SYSCALL instruction triggers the syscall
-//   - rcx and r11 are clobbered by SYSCALL instruction
-//
-// We cannot use the glibc syscall() wrapper because glibc isn't
-// initialized yet when IFUNC resolvers run.
-// ===================================================================
-
-__attribute__((no_stack_protector)) static long ifunc_syscall_3(long nr, long arg0, long arg1, long arg2) {
-  long ret;
-  __asm__ volatile("syscall" : "=a"(ret) : "a"(nr), "D"(arg0), "S"(arg1), "d"(arg2) : "rcx", "r11", "memory", "cc");
-  return ret;
-}
-
-__attribute__((no_stack_protector)) static long ifunc_syscall_4(long nr, long arg0, long arg1, long arg2, long arg3) {
-  long ret;
-  __asm__ volatile("syscall"
-                   : "=a"(ret)
-                   : "a"(nr), "D"(arg0), "S"(arg1), "d"(arg2), "r"((long)arg3)
-                   : "rcx", "r11", "memory", "cc");
-  return ret;
-}
-
-__attribute__((no_stack_protector)) static long ifunc_syscall_1(long nr, long arg0) {
-  long ret;
-  __asm__ volatile("syscall" : "=a"(ret) : "a"(nr), "D"(arg0) : "rcx", "r11", "memory", "cc");
-  return ret;
-}
-
-// Direct syscall wrappers using inline assembly
-__attribute__((no_stack_protector)) static int ifunc_sys_open(const char *pathname, int flags) {
-  // x86_64 still has the open syscall (SYS_open = 2)
-  // But we'll use openat for consistency
-  return ifunc_syscall_4(SYS_openat, -100 /* AT_FDCWD */, (long)pathname, flags, 0);
-}
-
-__attribute__((no_stack_protector)) static ssize_t ifunc_sys_read(int fd, void *buf, size_t count) {
-  return ifunc_syscall_3(SYS_read, fd, (long)buf, count);
-}
-
-__attribute__((no_stack_protector)) static int ifunc_sys_close(int fd) {
-  return ifunc_syscall_1(SYS_close, fd);
-}
-
-#else
-// For other architectures, fall back to hardcoded 4k (conservative)
-static size_t getPageSizeFromAuxv() {
-  return kPageSize4K;
-}
-#endif
-
-#if defined(__aarch64__) || defined(__x86_64__)
-// ===================================================================
-// Page Size Detection via Auxiliary Vector
-// ===================================================================
-// This function reads the page size from the kernel's auxiliary vector
-// by directly parsing /proc/self/auxv. We CANNOT use getauxval(AT_PAGESZ)
-// because:
-//   1. getauxval() is part of glibc which isn't initialized yet
-//   2. We're running in the IFUNC resolver context before libraries load
-//
-// The auxiliary vector is a set of key-value pairs passed by the kernel
-// to each process at startup, containing information like page size,
-// clock tick rate, etc. AT_PAGESZ (type 6) contains the system page size.
-//
-// We must:
-//   - Open /proc/self/auxv using raw syscalls (no open() function)
-//   - Read it using raw syscalls (no read() function)
-//   - Parse the Elf64_auxv_t structures manually
-//   - Use conservative fallbacks if anything fails
-//
-// Fallback values:
-//   - ARM64: 16KB (common on newer ARM64 systems, safe for 4KB systems)
-//   - x86_64: 4KB (standard and only option on x86_64)
-// ===================================================================
-__attribute__((no_stack_protector)) static size_t getPageSizeFromAuxv() {
-  // Use stack buffer to avoid any heap allocation (malloc not available)
-  // 512 bytes is enough to hold several auxv entries
-  unsigned char buffer[512];
-  int fd = ifunc_sys_open("/proc/self/auxv", O_RDONLY);
-
-  if (fd < 0) {
-    // Can't open /proc/self/auxv, fall back
-#ifdef __aarch64__
-    return kPageSize16K;  // ARM64 commonly uses 16k pages
-#else
-    return kPageSize4K;  // x86_64 uses 4k pages
-#endif
-  }
-
-  ssize_t bytes_read = ifunc_sys_read(fd, buffer, sizeof(buffer));
-  ifunc_sys_close(fd);
-
-  if (bytes_read < (ssize_t)sizeof(Elf64_auxv_t)) {
-    // Not enough data read
-#ifdef __aarch64__
-    return kPageSize16K;
-#else
-    return kPageSize4K;
-#endif
-  }
-
-  // Parse the auxiliary vector
-  Elf64_auxv_t *auxv = (Elf64_auxv_t *)buffer;
-  Elf64_auxv_t *auxv_end = (Elf64_auxv_t *)(buffer + bytes_read);
-
-  while (auxv < auxv_end && auxv->a_type != AT_NULL) {
-    if (auxv->a_type == AT_PAGESZ) {
-      size_t pagesize = auxv->a_un.a_val;
-      // Sanity check the value - we ONLY support 4KB and 16KB page sizes
-      // 4KB: Standard on x86_64 and older ARM64
-      // 16KB: Common on newer ARM64 systems (Apple Silicon, some Linux)
-      // Any other page size (including 64KB) is NOT supported
-      if (pagesize == kPageSize4K || pagesize == kPageSize16K) {
-        return pagesize;
-      }
-      // Invalid page size, fall back
-#ifdef __aarch64__
-      return kPageSize16K;
-#else
-      return kPageSize4K;
-#endif
-    }
-    auxv++;
-  }
-
-  // AT_PAGESZ not found (should never happen on Linux)
-#ifdef __aarch64__
-  return kPageSize16K;
-#else
-  return kPageSize4K;
-#endif
-}
-#endif
-
-#endif
 
 static __attribute__((constructor)) void libmesh_init() {
   mesh::real::init();
@@ -448,32 +217,32 @@ typedef void *(*memalign_func)(size_t, size_t);
 typedef void *(*calloc_func)(size_t, size_t);
 
 __attribute__((no_stack_protector)) static malloc_func resolve_mesh_malloc() {
-  size_t pageSize = getPageSizeFromAuxv();
+  size_t pageSize = mesh::ifunc::getPageSizeFromAuxv();
   return (pageSize == kPageSize4K) ? mesh_malloc_impl<kPageSize4K> : mesh_malloc_impl<kPageSize16K>;
 }
 __attribute__((no_stack_protector)) static free_func resolve_mesh_free() {
-  size_t pageSize = getPageSizeFromAuxv();
+  size_t pageSize = mesh::ifunc::getPageSizeFromAuxv();
   return (pageSize == kPageSize4K) ? mesh_free_impl<kPageSize4K> : mesh_free_impl<kPageSize16K>;
 }
 __attribute__((no_stack_protector)) static sized_free_func resolve_mesh_sized_free() {
-  size_t pageSize = getPageSizeFromAuxv();
+  size_t pageSize = mesh::ifunc::getPageSizeFromAuxv();
   return (pageSize == kPageSize4K) ? mesh_sized_free_impl<kPageSize4K> : mesh_sized_free_impl<kPageSize16K>;
 }
 __attribute__((no_stack_protector)) static realloc_func resolve_mesh_realloc() {
-  size_t pageSize = getPageSizeFromAuxv();
+  size_t pageSize = mesh::ifunc::getPageSizeFromAuxv();
   return (pageSize == kPageSize4K) ? mesh_realloc_impl<kPageSize4K> : mesh_realloc_impl<kPageSize16K>;
 }
 __attribute__((no_stack_protector)) static usable_size_func resolve_mesh_malloc_usable_size() {
-  size_t pageSize = getPageSizeFromAuxv();
+  size_t pageSize = mesh::ifunc::getPageSizeFromAuxv();
   return (pageSize == kPageSize4K) ? mesh_malloc_usable_size_impl<kPageSize4K>
                                    : mesh_malloc_usable_size_impl<kPageSize16K>;
 }
 __attribute__((no_stack_protector)) static memalign_func resolve_mesh_memalign() {
-  size_t pageSize = getPageSizeFromAuxv();
+  size_t pageSize = mesh::ifunc::getPageSizeFromAuxv();
   return (pageSize == kPageSize4K) ? mesh_memalign_impl<kPageSize4K> : mesh_memalign_impl<kPageSize16K>;
 }
 __attribute__((no_stack_protector)) static calloc_func resolve_mesh_calloc() {
-  size_t pageSize = getPageSizeFromAuxv();
+  size_t pageSize = mesh::ifunc::getPageSizeFromAuxv();
   return (pageSize == kPageSize4K) ? mesh_calloc_impl<kPageSize4K> : mesh_calloc_impl<kPageSize16K>;
 }
 }

--- a/src/mini_heap.h
+++ b/src/mini_heap.h
@@ -179,6 +179,7 @@ private:
 public:
   using BitmapType = internal::Bitmap<PageSize>;
   using ListEntryType = MiniHeapListEntry<PageSize>;
+  static constexpr size_t kPageSize = PageSize;
   static constexpr unsigned kPageShift = __builtin_ctzl(PageSize);
 
   MiniHeap(void *arenaBegin, Span span, size_t objectCount, size_t objectSize)

--- a/src/shuffle_vector.h
+++ b/src/shuffle_vector.h
@@ -263,7 +263,7 @@ public:
     // Cap at 1024 for bitmap limit. Shuffle vector now uses uint16_t in sv::Entry
     // so it can track up to 1024 objects (matching bitmap capacity)
     const size_t bitmapLimit = PageSize / kMinObjectSize;
-    _maxCount = min(max(getPageSize() / sz, static_cast<size_t>(kMinStringLen)), static_cast<size_t>(bitmapLimit));
+    _maxCount = min(max(PageSize / sz, static_cast<size_t>(kMinStringLen)), static_cast<size_t>(bitmapLimit));
     // initially, we are unattached and therefor have no capacity.
     // Setting _off to _maxCount causes isExhausted() to return true
     // so that we don't separately have to check !isAttached() in the

--- a/src/thread_local_heap.h
+++ b/src/thread_local_heap.h
@@ -99,7 +99,7 @@ public:
       // if the alignment is for a small allocation that is less than
       // the page size, and the size class size in bytes is a multiple
       // of the alignment, just call malloc
-      if (sizeClassBytes <= getPageSize() && alignment <= sizeClassBytes && (sizeClassBytes % alignment) == 0) {
+      if (sizeClassBytes <= PageSize && alignment <= sizeClassBytes && (sizeClassBytes % alignment) == 0) {
         auto ptr = this->malloc(size);
         d_assert_msg((reinterpret_cast<uintptr_t>(ptr) % alignment) == 0, "%p(%zu) %% %zu != 0", ptr, size, alignment);
         return ptr;
@@ -107,7 +107,7 @@ public:
     }
 
     // fall back to page-aligned allocation
-    const size_t pageAlignment = (alignment + getPageSize() - 1) / getPageSize();
+    const size_t pageAlignment = (alignment + PageSize - 1) / PageSize;
     const size_t pageCount = PageCount(size);
     return _global->pageAlignedAlloc(pageAlignment, pageCount);
   }

--- a/src/wrapper.cc
+++ b/src/wrapper.cc
@@ -356,7 +356,7 @@ MESH_EXPORT CACHELINE_ALIGNED_FN void *operator new(size_t sz)
     _GLIBCXX_THROW(std::bad_alloc)
 #endif
 #ifdef __linux__
-    __attribute__((ifunc("resolve_cxx_new")));
+        __attribute__((ifunc("resolve_cxx_new")));
 #else
 {
   if (likely(getPageSize() == kPageSize4K)) {
@@ -399,7 +399,7 @@ MESH_EXPORT CACHELINE_ALIGNED_FN void *operator new[](size_t sz)
     _GLIBCXX_THROW(std::bad_alloc)
 #endif
 #ifdef __linux__
-    __attribute__((ifunc("resolve_cxx_new")));
+        __attribute__((ifunc("resolve_cxx_new")));
 #else
 {
   if (likely(getPageSize() == kPageSize4K)) {


### PR DESCRIPTION
Also fixes mesh on `x86_64`.

`getPageSize()` _looks_ very reasonable, but under the hood there is a c++ static initialization guard checked w/ an atomic load, and I believe that caused a bunch of cacheline contention: https://godbolt.org/z/Me6W5s84M

A bunch of the runtime is _already_ templated with the page size, so with a little care we can mostly use that to avoid the hidden costs w/ getPageSize().

Also, sharding the global lock is hugely helpful - I mistakenly assumed it initially wasn't because the robot was spectacularly close but wrong: it sharded the lock, but then "protected" those sharded locks w/ a new global lock.  Additionally, we manage the initial freelist queuing outside a lock now: when a miniheap goes from full -> partially full, we atomically queue it, and the next thread that needs space grabs the queued miniheaps and adds them to the freelist.