### PR TITLE
fix: check SA_SIGINFO flag before calling sa_sigaction

### DIFF
--- a/src/runtime_impl.h
+++ b/src/runtime_impl.h
@@ -335,7 +335,7 @@ void Runtime<PageSize>::segfaultHandler(int sig, siginfo_t *siginfo, void *conte
   }
 
   if (action != nullptr) {
-    if (action->sa_sigaction != nullptr) {
+    if ((action->sa_flags & SA_SIGINFO) && action->sa_sigaction != nullptr) {
       action->sa_sigaction(sig, siginfo, context);
       return;
     } else if (action->sa_handler == SIG_IGN) {


### PR DESCRIPTION
Previously the code assumed any non-null handler should be called with
the 3-argument sa_sigaction signature. Since sa_handler and sa_sigaction
are a union, this would incorrectly call simple 1-argument handlers with
3 arguments. Now we check SA_SIGINFO flag to determine the correct
calling convention.
